### PR TITLE
feat(typescript): add TypeScript SDK implementation

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,98 @@
+# @everruns/sdk
+
+TypeScript SDK for the Everruns API.
+
+## Installation
+
+\`\`\`bash
+npm install @everruns/sdk
+\`\`\`
+
+## Quick Start
+
+\`\`\`typescript
+import { Everruns } from "@everruns/sdk";
+
+// Uses EVERRUNS_API_KEY environment variable
+const client = Everruns.fromEnv("my-org");
+
+// Create an agent
+const agent = await client.agents.create({
+  name: "Assistant",
+  systemPrompt: "You are a helpful assistant."
+});
+
+// Create a session
+const session = await client.sessions.create({ agentId: agent.id });
+
+// Send a message
+await client.messages.create(session.id, { text: "Hello!" });
+
+// Stream events
+for await (const event of client.events.stream(session.id)) {
+  console.log(event.type, event.data);
+}
+\`\`\`
+
+## Authentication
+
+The SDK uses API key authentication. Set the \`EVERRUNS_API_KEY\` environment variable or pass the key explicitly:
+
+\`\`\`typescript
+// From environment variable
+const client = Everruns.fromEnv("my-org");
+
+// Explicit key
+const client = new Everruns({
+  apiKey: "evr_...",
+  org: "my-org"
+});
+\`\`\`
+
+## Streaming Events
+
+The SDK supports SSE streaming with automatic reconnection:
+
+\`\`\`typescript
+const stream = client.events.stream(session.id, {
+  exclude: ["output.message.delta"],  // Filter out delta events
+  sinceId: "evt_..."                   // Resume from event ID
+});
+
+for await (const event of stream) {
+  switch (event.type) {
+    case "output.message.completed":
+      console.log("Message:", event.data);
+      break;
+    case "turn.completed":
+      console.log("Turn completed");
+      stream.abort();  // Stop streaming
+      break;
+    case "turn.failed":
+      console.error("Turn failed:", event.data);
+      break;
+  }
+}
+\`\`\`
+
+## Error Handling
+
+\`\`\`typescript
+import { ApiError, AuthenticationError, RateLimitError } from "@everruns/sdk";
+
+try {
+  await client.agents.get("invalid-id");
+} catch (error) {
+  if (error instanceof AuthenticationError) {
+    console.error("Invalid API key");
+  } else if (error instanceof RateLimitError) {
+    console.log(\`Retry after \${error.retryAfter} seconds\`);
+  } else if (error instanceof ApiError) {
+    console.error(\`API error \${error.statusCode}: \${error.message}\`);
+  }
+}
+\`\`\`
+
+## License
+
+MIT

--- a/typescript/examples/basic.ts
+++ b/typescript/examples/basic.ts
@@ -1,0 +1,48 @@
+/**
+ * Basic usage example for Everruns SDK.
+ *
+ * Set EVERRUNS_API_KEY environment variable before running:
+ * export EVERRUNS_API_KEY=evr_...
+ * npx tsx examples/basic.ts
+ */
+import { Everruns } from "@everruns/sdk";
+
+async function main() {
+  // Create client using EVERRUNS_API_KEY env var
+  const client = Everruns.fromEnv("my-org");
+
+  // Create an agent
+  const agent = await client.agents.create({
+    name: "Assistant",
+    systemPrompt: "You are a helpful assistant.",
+  });
+  console.log("Created agent:", agent.id);
+
+  // Create a session
+  const session = await client.sessions.create({ agentId: agent.id });
+  console.log("Created session:", session.id);
+
+  // Send a message
+  const message = await client.messages.create(session.id, {
+    text: "Hello! What can you help me with?",
+  });
+  console.log("Sent message:", message.id);
+
+  // Stream events
+  console.log("Streaming events...");
+  const stream = client.events.stream(session.id, {
+    exclude: ["output.message.delta"],
+  });
+
+  for await (const event of stream) {
+    console.log(\`[\${event.type}]\`, JSON.stringify(event.data).slice(0, 100));
+    
+    if (event.type === "turn.completed" || event.type === "turn.failed") {
+      break;
+    }
+  }
+
+  console.log("Done!");
+}
+
+main().catch(console.error);

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@everruns/sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for Everruns API",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src",
+    "format": "prettier --write src",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": ["everruns", "sdk", "api", "ai", "agents"],
+  "author": "Everruns Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/everruns/sdk.git",
+    "directory": "typescript"
+  },
+  "homepage": "https://github.com/everruns/sdk#readme",
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "eventsource-parser": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0",
+    "eslint": "^9.0.0",
+    "prettier": "^3.4.0"
+  }
+}

--- a/typescript/src/auth.ts
+++ b/typescript/src/auth.ts
@@ -1,0 +1,35 @@
+/**
+ * API key authentication for Everruns API.
+ */
+export class ApiKey {
+  private readonly key: string;
+
+  constructor(key: string) {
+    if (!key) {
+      throw new Error("API key cannot be empty");
+    }
+    this.key = key;
+  }
+
+  /**
+   * Create an ApiKey from the EVERRUNS_API_KEY environment variable.
+   * @throws Error if the environment variable is not set
+   */
+  static fromEnv(): ApiKey {
+    const key = process.env.EVERRUNS_API_KEY;
+    if (!key) {
+      throw new Error(
+        "EVERRUNS_API_KEY environment variable is not set. " +
+        "Set it to your Everruns API key or pass the key explicitly."
+      );
+    }
+    return new ApiKey(key);
+  }
+
+  /**
+   * Get the authorization header value.
+   */
+  toHeader(): string {
+    return this.key;
+  }
+}

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1,0 +1,192 @@
+/**
+ * Everruns API client.
+ */
+import { ApiKey } from "./auth.js";
+import {
+  Agent,
+  CreateAgentRequest,
+  Session,
+  CreateSessionRequest,
+  Message,
+  CreateMessageRequest,
+  Event,
+  StreamOptions,
+} from "./models.js";
+import { ApiError, AuthenticationError, NotFoundError, RateLimitError } from "./errors.js";
+import { EventStream } from "./sse.js";
+
+export interface EverrunsOptions {
+  apiKey?: string | ApiKey;
+  org: string;
+  baseUrl?: string;
+}
+
+export class Everruns {
+  private readonly apiKey: ApiKey;
+  private readonly org: string;
+  private readonly baseUrl: string;
+
+  readonly agents: AgentsClient;
+  readonly sessions: SessionsClient;
+  readonly messages: MessagesClient;
+  readonly events: EventsClient;
+
+  constructor(options: EverrunsOptions) {
+    if (options.apiKey instanceof ApiKey) {
+      this.apiKey = options.apiKey;
+    } else if (options.apiKey) {
+      this.apiKey = new ApiKey(options.apiKey);
+    } else {
+      this.apiKey = ApiKey.fromEnv();
+    }
+    this.org = options.org;
+    this.baseUrl = options.baseUrl ?? "https://api.everruns.com";
+
+    this.agents = new AgentsClient(this);
+    this.sessions = new SessionsClient(this);
+    this.messages = new MessagesClient(this);
+    this.events = new EventsClient(this);
+  }
+
+  /**
+   * Create a client using the EVERRUNS_API_KEY environment variable.
+   */
+  static fromEnv(org: string, baseUrl?: string): Everruns {
+    return new Everruns({ org, baseUrl });
+  }
+
+  async fetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const url = \`\${this.baseUrl}/orgs/\${this.org}\${path}\`;
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        "Authorization": this.apiKey.toHeader(),
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => undefined);
+      if (response.status === 401) {
+        throw new AuthenticationError();
+      }
+      if (response.status === 404) {
+        throw new NotFoundError("Resource");
+      }
+      if (response.status === 429) {
+        const retryAfter = response.headers.get("Retry-After");
+        throw new RateLimitError(retryAfter ? parseInt(retryAfter, 10) : undefined);
+      }
+      throw new ApiError(response.status, \`API error: \${response.statusText}\`, body);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  getStreamUrl(path: string): string {
+    return \`\${this.baseUrl}/orgs/\${this.org}\${path}\`;
+  }
+
+  getAuthHeader(): string {
+    return this.apiKey.toHeader();
+  }
+}
+
+class AgentsClient {
+  constructor(private readonly client: Everruns) {}
+
+  async create(request: CreateAgentRequest): Promise<Agent> {
+    return this.client.fetch("/agents", {
+      method: "POST",
+      body: JSON.stringify({
+        name: request.name,
+        system_prompt: request.systemPrompt,
+        model: request.model,
+      }),
+    });
+  }
+
+  async get(agentId: string): Promise<Agent> {
+    return this.client.fetch(\`/agents/\${agentId}\`);
+  }
+
+  async list(): Promise<Agent[]> {
+    const response = await this.client.fetch<{ agents: Agent[] }>("/agents");
+    return response.agents;
+  }
+
+  async delete(agentId: string): Promise<void> {
+    await this.client.fetch(\`/agents/\${agentId}\`, { method: "DELETE" });
+  }
+}
+
+class SessionsClient {
+  constructor(private readonly client: Everruns) {}
+
+  async create(request: CreateSessionRequest): Promise<Session> {
+    return this.client.fetch("/sessions", {
+      method: "POST",
+      body: JSON.stringify({ agent_id: request.agentId }),
+    });
+  }
+
+  async get(sessionId: string): Promise<Session> {
+    return this.client.fetch(\`/sessions/\${sessionId}\`);
+  }
+
+  async list(agentId?: string): Promise<Session[]> {
+    const query = agentId ? \`?agent_id=\${agentId}\` : "";
+    const response = await this.client.fetch<{ sessions: Session[] }>(\`/sessions\${query}\`);
+    return response.sessions;
+  }
+}
+
+class MessagesClient {
+  constructor(private readonly client: Everruns) {}
+
+  async create(sessionId: string, request: CreateMessageRequest): Promise<Message> {
+    return this.client.fetch(\`/sessions/\${sessionId}/messages\`, {
+      method: "POST",
+      body: JSON.stringify({
+        text: request.text,
+        image_urls: request.imageUrls,
+      }),
+    });
+  }
+
+  async list(sessionId: string): Promise<Message[]> {
+    const response = await this.client.fetch<{ messages: Message[] }>(
+      \`/sessions/\${sessionId}/messages\`
+    );
+    return response.messages;
+  }
+}
+
+class EventsClient {
+  constructor(private readonly client: Everruns) {}
+
+  async list(sessionId: string, options?: StreamOptions): Promise<Event[]> {
+    const params = new URLSearchParams();
+    if (options?.sinceId) params.set("since_id", options.sinceId);
+    if (options?.exclude) params.set("exclude", options.exclude.join(","));
+    const query = params.toString() ? \`?\${params}\` : "";
+    const response = await this.client.fetch<{ events: Event[] }>(
+      \`/sessions/\${sessionId}/events\${query}\`
+    );
+    return response.events;
+  }
+
+  stream(sessionId: string, options?: StreamOptions): EventStream {
+    const params = new URLSearchParams();
+    if (options?.sinceId) params.set("since_id", options.sinceId);
+    if (options?.exclude) params.set("exclude", options.exclude.join(","));
+    const query = params.toString() ? \`?\${params}\` : "";
+    const url = this.client.getStreamUrl(\`/sessions/\${sessionId}/events/stream\${query}\`);
+    return new EventStream(url, this.client.getAuthHeader());
+  }
+}

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -1,0 +1,53 @@
+/**
+ * Error types for Everruns SDK.
+ */
+
+export class EverrunsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EverrunsError";
+  }
+}
+
+export class ApiError extends EverrunsError {
+  readonly statusCode: number;
+  readonly body?: unknown;
+
+  constructor(statusCode: number, message: string, body?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+    this.body = body;
+  }
+}
+
+export class AuthenticationError extends ApiError {
+  constructor(message: string = "Authentication failed") {
+    super(401, message);
+    this.name = "AuthenticationError";
+  }
+}
+
+export class NotFoundError extends ApiError {
+  constructor(resource: string) {
+    super(404, \`\${resource} not found\`);
+    this.name = "NotFoundError";
+  }
+}
+
+export class RateLimitError extends ApiError {
+  readonly retryAfter?: number;
+
+  constructor(retryAfter?: number) {
+    super(429, "Rate limit exceeded");
+    this.name = "RateLimitError";
+    this.retryAfter = retryAfter;
+  }
+}
+
+export class ConnectionError extends EverrunsError {
+  constructor(message: string = "Connection failed") {
+    super(message);
+    this.name = "ConnectionError";
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Everruns SDK for TypeScript/Node.js
+ *
+ * @example
+ * ```typescript
+ * import { Everruns } from "@everruns/sdk";
+ *
+ * // Uses EVERRUNS_API_KEY environment variable
+ * const client = Everruns.fromEnv("my-org");
+ *
+ * // Create an agent
+ * const agent = await client.agents.create({
+ *   name: "Assistant",
+ *   systemPrompt: "You are a helpful assistant."
+ * });
+ *
+ * // Create a session
+ * const session = await client.sessions.create({ agentId: agent.id });
+ *
+ * // Send a message
+ * await client.messages.create(session.id, { text: "Hello!" });
+ * ```
+ */
+
+export { Everruns, type EverrunsOptions } from "./client.js";
+export { ApiKey } from "./auth.js";
+export * from "./models.js";
+export * from "./errors.js";
+export { EventStream } from "./sse.js";

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -1,0 +1,63 @@
+/**
+ * Core data models for Everruns API.
+ */
+
+export interface Agent {
+  id: string;
+  name: string;
+  systemPrompt: string;
+  model?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAgentRequest {
+  name: string;
+  systemPrompt: string;
+  model?: string;
+}
+
+export interface Session {
+  id: string;
+  agentId: string;
+  status: "active" | "completed" | "failed";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSessionRequest {
+  agentId: string;
+}
+
+export interface Message {
+  id: string;
+  sessionId: string;
+  role: "user" | "assistant";
+  content: ContentPart[];
+  createdAt: string;
+}
+
+export interface ContentPart {
+  type: "text" | "image";
+  text?: string;
+  imageUrl?: string;
+}
+
+export interface CreateMessageRequest {
+  text?: string;
+  imageUrls?: string[];
+}
+
+export interface Event {
+  id: string;
+  type: string;
+  data: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface StreamOptions {
+  /** Resume from this event ID */
+  sinceId?: string;
+  /** Event types to exclude from the stream */
+  exclude?: string[];
+}

--- a/typescript/src/sse.ts
+++ b/typescript/src/sse.ts
@@ -1,0 +1,104 @@
+/**
+ * Server-Sent Events streaming for Everruns API.
+ */
+import { createParser, type EventSourceMessage } from "eventsource-parser";
+import { Event } from "./models.js";
+import { ConnectionError } from "./errors.js";
+
+/**
+ * Async iterator for SSE events with automatic reconnection.
+ */
+export class EventStream implements AsyncIterable<Event> {
+  private readonly url: string;
+  private readonly authHeader: string;
+  private lastEventId?: string;
+  private abortController?: AbortController;
+
+  constructor(url: string, authHeader: string) {
+    this.url = url;
+    this.authHeader = authHeader;
+  }
+
+  /**
+   * Abort the stream.
+   */
+  abort(): void {
+    this.abortController?.abort();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<Event> {
+    this.abortController = new AbortController();
+
+    while (true) {
+      try {
+        const url = this.lastEventId
+          ? \`\${this.url}\${this.url.includes("?") ? "&" : "?"}since_id=\${this.lastEventId}\`
+          : this.url;
+
+        const response = await fetch(url, {
+          headers: {
+            Authorization: this.authHeader,
+            Accept: "text/event-stream",
+            "Cache-Control": "no-cache",
+          },
+          signal: this.abortController.signal,
+        });
+
+        if (!response.ok) {
+          throw new ConnectionError(\`Stream connection failed: \${response.status}\`);
+        }
+
+        if (!response.body) {
+          throw new ConnectionError("No response body");
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        
+        const eventQueue: Event[] = [];
+        let resolveNext: ((value: IteratorResult<Event>) => void) | null = null;
+
+        const parser = createParser({
+          onEvent: (event: EventSourceMessage) => {
+            if (event.event === "done") {
+              return;
+            }
+            try {
+              const data = JSON.parse(event.data) as Event;
+              this.lastEventId = data.id;
+              if (resolveNext) {
+                resolveNext({ value: data, done: false });
+                resolveNext = null;
+              } else {
+                eventQueue.push(data);
+              }
+            } catch {
+              // Skip malformed events
+            }
+          },
+        });
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          
+          const chunk = decoder.decode(value, { stream: true });
+          parser.feed(chunk);
+
+          while (eventQueue.length > 0) {
+            yield eventQueue.shift()!;
+          }
+        }
+
+        // Stream ended normally
+        return;
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
+        // Reconnect after brief delay
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+  }
+}

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { ApiKey } from "../src/auth.js";
+import { Everruns } from "../src/client.js";
+
+describe("ApiKey", () => {
+  it("should create from string", () => {
+    const key = new ApiKey("evr_test_key");
+    expect(key.toHeader()).toBe("evr_test_key");
+  });
+
+  it("should throw on empty key", () => {
+    expect(() => new ApiKey("")).toThrow("API key cannot be empty");
+  });
+});
+
+describe("Everruns", () => {
+  it("should create client with explicit key", () => {
+    const client = new Everruns({
+      apiKey: "evr_test_key",
+      org: "test-org",
+    });
+    expect(client).toBeDefined();
+    expect(client.agents).toBeDefined();
+    expect(client.sessions).toBeDefined();
+    expect(client.messages).toBeDefined();
+    expect(client.events).toBeDefined();
+  });
+
+  it("should create client with ApiKey instance", () => {
+    const apiKey = new ApiKey("evr_test_key");
+    const client = new Everruns({
+      apiKey,
+      org: "test-org",
+    });
+    expect(client).toBeDefined();
+  });
+
+  it("should use custom base URL", () => {
+    const client = new Everruns({
+      apiKey: "evr_test_key",
+      org: "test-org",
+      baseUrl: "https://custom.api.com",
+    });
+    expect(client.getStreamUrl("/test")).toBe(
+      "https://custom.api.com/orgs/test-org/test"
+    );
+  });
+});

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests", "examples"]
+}


### PR DESCRIPTION
## Summary

Adds `@everruns/sdk` TypeScript/Node.js package with:

- `Everruns` client with `agents`, `sessions`, `messages`, `events` sub-clients
- `ApiKey` authentication with `EVERRUNS_API_KEY` env var support
- `EventStream` async iterator for SSE streaming with auto-reconnection
- TypeScript interfaces for Agent, Session, Message, Event
- Error hierarchy: `ApiError`, `AuthenticationError`, `RateLimitError`, `NotFoundError`
- Unit tests with vitest
- Example code

## Files

- `typescript/package.json` - Package config for npm
- `typescript/tsconfig.json` - TypeScript compiler settings
- `typescript/src/index.ts` - Main exports
- `typescript/src/client.ts` - Everruns client implementation
- `typescript/src/auth.ts` - API key handling
- `typescript/src/models.ts` - TypeScript interfaces
- `typescript/src/errors.ts` - Error classes
- `typescript/src/sse.ts` - SSE streaming with eventsource-parser
- `typescript/tests/client.test.ts` - Unit tests
- `typescript/examples/basic.ts` - Usage example
- `typescript/README.md` - Package documentation

## Test Plan

- [ ] `npm ci` installs dependencies
- [ ] `npm run build` compiles TypeScript
- [ ] `npm test` passes
- [ ] `npm run lint` passes