### PR TITLE
chore: add publish prep files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to the Everruns SDKs will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-01-25
+
+### Added
+
+**All SDKs:**
+- Initial release with core functionality
+- `Everruns` client with `agents`, `sessions`, `messages`, `events` sub-clients
+- `ApiKey` authentication with `EVERRUNS_API_KEY` environment variable support
+- SSE streaming with automatic reconnection via `since_id`
+- Event filtering with `exclude` parameter
+- Typed error handling
+
+**Rust SDK (everruns-sdk):**
+- Async/await API with tokio
+- `EventStream` implementing `futures::Stream`
+- Secure API key handling with `secrecy` crate
+
+**Python SDK (everruns-sdk):**
+- Async client with httpx
+- Pydantic models for request/response validation
+- `EventStream` async iterator
+
+**TypeScript SDK (@everruns/sdk):**
+- Native fetch-based client
+- TypeScript interfaces with full type safety
+- `EventStream` async iterator with eventsource-parser

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Rust SDK for Everruns API"
 license = "MIT"
+readme = "README.md"
 repository = "https://github.com/everruns/sdk"
 documentation = "https://docs.rs/everruns-sdk"
 keywords = ["everruns", "sdk", "api", "ai", "agents"]

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,101 @@
+# everruns-sdk
+
+Rust SDK for the Everruns API.
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+\`\`\`toml
+[dependencies]
+everruns-sdk = "0.1"
+\`\`\`
+
+## Quick Start
+
+\`\`\`rust
+use everruns_sdk::Everruns;
+
+#[tokio::main]
+async fn main() -> Result<(), everruns_sdk::Error> {
+    // Uses EVERRUNS_API_KEY environment variable
+    let client = Everruns::from_env("my-org")?;
+
+    // Create an agent
+    let agent = client.agents().create(
+        "Assistant",
+        "You are a helpful assistant."
+    ).await?;
+
+    // Create a session
+    let session = client.sessions().create(&agent.id).await?;
+
+    // Send a message
+    client.messages().create(&session.id, "Hello!").await?;
+
+    Ok(())
+}
+\`\`\`
+
+## Authentication
+
+The SDK uses API key authentication. Set the \`EVERRUNS_API_KEY\` environment variable or pass the key explicitly:
+
+\`\`\`rust
+// From environment variable
+let client = Everruns::from_env("my-org")?;
+
+// Explicit key
+let client = Everruns::new("evr_...", "my-org");
+\`\`\`
+
+## Streaming Events
+
+The SDK supports SSE streaming with automatic reconnection:
+
+\`\`\`rust
+use futures::StreamExt;
+use everruns_sdk::StreamOptions;
+
+let stream = client.events().stream(
+    &session.id,
+    StreamOptions::default().exclude(vec!["output.message.delta".into()])
+).await?;
+
+while let Some(event) = stream.next().await {
+    match event?.event_type.as_str() {
+        "output.message.completed" => {
+            println!("Message: {:?}", event.data);
+        }
+        "turn.completed" => {
+            println!("Turn completed");
+            break;
+        }
+        "turn.failed" => {
+            eprintln!("Turn failed: {:?}", event.data);
+            break;
+        }
+        _ => {}
+    }
+}
+\`\`\`
+
+## Error Handling
+
+\`\`\`rust
+use everruns_sdk::Error;
+
+match client.agents().get("invalid-id").await {
+    Ok(agent) => println!("Agent: {:?}", agent),
+    Err(Error::Authentication(_)) => eprintln!("Invalid API key"),
+    Err(Error::NotFound(_)) => eprintln!("Agent not found"),
+    Err(Error::RateLimit { retry_after }) => {
+        eprintln!("Rate limited, retry after {:?}", retry_after);
+    }
+    Err(e) => eprintln!("Error: {}", e),
+}
+\`\`\`
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Prepares all SDKs for v0.1.0 publish:

- Add `rust/README.md` for crates.io display
- Add `readme = "README.md"` to `rust/Cargo.toml`
- Add `CHANGELOG.md` with initial v0.1.0 release notes

## Test Plan

- [ ] `cargo publish --dry-run` succeeds for Rust SDK
- [ ] All SDKs have README files