### PR TITLE
feat(ci): add job to run Rust cookbook with everruns-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,17 +65,17 @@ jobs:
           workspaces: |
             rust
             cookbook/rust
-      - name: Get everruns Cargo.lock hash
-        id: everruns-lock
+      - name: Get everruns-server latest commit
+        id: everruns-sha
         run: |
-          HASH=$(curl -sL https://raw.githubusercontent.com/everruns/everruns/main/Cargo.lock | sha256sum | cut -d' ' -f1)
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
+          SHA=$(git ls-remote https://github.com/everruns/everruns.git HEAD | cut -f1)
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
       - name: Cache everruns-server binary
         id: cache-server
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/everruns-server
-          key: everruns-server-${{ runner.os }}-${{ steps.everruns-lock.outputs.hash }}
+          key: everruns-server-${{ runner.os }}-${{ steps.everruns-sha.outputs.sha }}
       - name: Install everruns-server
         if: steps.cache-server.outputs.cache-hit != 'true'
         run: cargo install --git https://github.com/everruns/everruns everruns-server


### PR DESCRIPTION
## Summary
- Adds new CI job `run-rust-cookbook` that runs the Rust cookbook example against everruns-server in dev mode
- Installs everruns-server from the everruns/everruns repo
- Configures server with `DEFAULT_ANTHROPIC_API_KEY` and `DEFAULT_OPENAI_API_KEY` from CI secrets

## Test plan
- [ ] CI job `run-rust-cookbook` passes
- [ ] Server starts successfully with dev mode
- [ ] Rust cookbook example runs and completes