### PR TITLE
docs: add comprehensive README with quick start examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = Everruns::from_env("my-org")?;
+    let client = Everruns::from_env("org_...")?;
 
     // Create an agent
     let agent = client.agents().create(
@@ -70,7 +70,7 @@ import asyncio
 from everruns_sdk import Everruns
 
 async def main():
-    client = Everruns(org="my-org")
+    client = Everruns(org="org_...")
 
     # Create an agent
     agent = await client.agents.create(
@@ -101,7 +101,7 @@ asyncio.run(main())
 import { Everruns } from "@everruns/sdk";
 
 async function main() {
-  const client = Everruns.fromEnv("my-org");
+  const client = Everruns.fromEnv("org_...");
 
   // Create an agent
   const agent = await client.agents.create({
@@ -159,17 +159,17 @@ All SDKs read from `EVERRUNS_API_KEY` environment variable by default, or accept
 
 ```rust
 // Rust
-let client = Everruns::new("evr_...", "my-org");
+let client = Everruns::new("evr_...", "org_...");
 ```
 
 ```python
 # Python
-client = Everruns(api_key="evr_...", org="my-org")
+client = Everruns(api_key="evr_...", org="org_...")
 ```
 
 ```typescript
 // TypeScript
-const client = new Everruns({ apiKey: "evr_...", org: "my-org" });
+const client = new Everruns({ apiKey: "evr_...", org: "org_..." });
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Summary
- Add complete README covering installation for all three SDKs (Rust, Python, TypeScript)
- Include quick start examples showing the full agent workflow
- Document API coverage, event types, authentication, and error handling
- Link to getting started docs and cookbook examples

## Test plan
- [x] Verify all code examples are syntactically correct
- [x] Confirm links point to existing files