### PR TITLE
refactor: remove org parameter from API endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,5 @@ jobs:
       - name: Run Rust cookbook example
         run: cd cookbook/rust && cargo run
         env:
-          EVERRUNS_ORG: org_00000000000000000000000000000001
           EVERRUNS_API_KEY: fake-key
           EVERRUNS_API_URL: http://localhost:9000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,19 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 
 ### OpenAPI
 
-`openapi/openapi.json` - Source of truth synced from everruns/everruns.
+`openapi/openapi.json` - Source of truth synced from [everruns/everruns](https://github.com/everruns/everruns).
+
+Source location: `docs/api/openapi.json` in everruns/everruns repo.
+
+To update: `curl -s "https://raw.githubusercontent.com/everruns/everruns/main/docs/api/openapi.json" > openapi/openapi.json`
+
+### GitHub API Access
+
+Public repos (e.g., everruns/everruns) accessible via GitHub API without auth:
+```bash
+curl -s "https://api.github.com/repos/everruns/everruns/contents"
+curl -s "https://raw.githubusercontent.com/everruns/everruns/main/path/to/file"
+```
 
 ### Cloud Agent Start
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = Everruns::from_env("org_...")?;
+    let client = Everruns::from_env()?;
 
     // Create an agent
     let agent = client.agents().create(
@@ -70,7 +70,7 @@ import asyncio
 from everruns_sdk import Everruns
 
 async def main():
-    client = Everruns(org="org_...")
+    client = Everruns()
 
     # Create an agent
     agent = await client.agents.create(
@@ -101,7 +101,7 @@ asyncio.run(main())
 import { Everruns } from "@everruns/sdk";
 
 async function main() {
-  const client = Everruns.fromEnv("org_...");
+  const client = Everruns.fromEnv();
 
   // Create an agent
   const agent = await client.agents.create({
@@ -159,17 +159,17 @@ All SDKs read from `EVERRUNS_API_KEY` environment variable by default, or accept
 
 ```rust
 // Rust
-let client = Everruns::new("evr_...", "org_...");
+let client = Everruns::new("evr_...");
 ```
 
 ```python
 # Python
-client = Everruns(api_key="evr_...", org="org_...")
+client = Everruns(api_key="evr_...")
 ```
 
 ```typescript
 // TypeScript
-const client = new Everruns({ apiKey: "evr_...", org: "org_..." });
+const client = new Everruns({ apiKey: "evr_..." });
 ```
 
 ## Error Handling

--- a/cookbook/rust/README.md
+++ b/cookbook/rust/README.md
@@ -10,7 +10,6 @@ export DEFAULT_ANTHROPIC_API_KEY=sk-ant-...  # or DEFAULT_OPENAI_API_KEY
 DEV_MODE=1 everruns-server
 
 # Terminal 2: Run example
-export EVERRUNS_ORG=org_00000000000000000000000000000001
 export EVERRUNS_API_KEY=fake-key
 export EVERRUNS_API_URL=http://localhost:9000
 cargo run

--- a/cookbook/rust/src/main.rs
+++ b/cookbook/rust/src/main.rs
@@ -99,11 +99,10 @@ fn extract_text(data: &serde_json::Value) -> Option<String> {
 }
 
 fn dev_client() -> Result<Everruns, everruns_sdk::Error> {
-    let org = std::env::var("EVERRUNS_ORG").expect("EVERRUNS_ORG required");
     let key = std::env::var("EVERRUNS_API_KEY").expect("EVERRUNS_API_KEY required");
 
     match std::env::var("EVERRUNS_API_URL") {
-        Ok(url) => Everruns::with_base_url(key, org, &url),
-        Err(_) => Everruns::new(key, org),
+        Ok(url) => Everruns::with_base_url(key, &url),
+        Err(_) => Everruns::new(key),
     }
 }

--- a/justfile
+++ b/justfile
@@ -71,6 +71,6 @@ check-cookbook:
 lint-cookbook:
     cd cookbook/rust && cargo fmt --check && cargo clippy -- -D warnings
 
-# Run cookbook (requires EVERRUNS_ORG, EVERRUNS_API_KEY, EVERRUNS_API_URL)
+# Run cookbook (requires EVERRUNS_API_KEY, EVERRUNS_API_URL)
 run-cookbook:
     cd cookbook/rust && cargo run

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -16,24 +16,13 @@
     }
   ],
   "paths": {
-    "/v1/orgs/{org}/agents": {
+    "/v1/agents": {
       "get": {
         "tags": [
           "agents"
         ],
-        "summary": "GET /v1/orgs/{org}/agents - List all active agents",
+        "summary": "GET /v1/agents - List all active agents",
         "operationId": "list_agents",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "List of agents",
@@ -54,19 +43,8 @@
         "tags": [
           "agents"
         ],
-        "summary": "POST /v1/orgs/{org}/agents - Create a new agent",
+        "summary": "POST /v1/agents - Create a new agent",
         "operationId": "create_agent",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -111,25 +89,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/agents/import": {
+    "/v1/agents/import": {
       "post": {
         "tags": [
           "agents"
         ],
-        "summary": "POST /v1/orgs/{org}/agents/import - Import agent from Markdown, YAML, or JSON",
+        "summary": "POST /v1/agents/import - Import agent from Markdown, YAML, or JSON",
         "description": "Accepts agent definition in multiple formats:\n- Markdown with YAML front matter (if starts with ---)\n- Pure YAML\n- Pure JSON\n- Plain text (treated as system prompt, name auto-generated)",
         "operationId": "import_agent",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "text/plain": {
@@ -174,23 +141,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/agents/{agent_id}": {
+    "/v1/agents/{agent_id}": {
       "get": {
         "tags": [
           "agents"
         ],
-        "summary": "GET /v1/orgs/{org}/agents/{agent_id} - Get agent by ID",
+        "summary": "GET /v1/agents/{agent_id} - Get agent by ID",
         "operationId": "get_agent",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "path",
@@ -227,18 +185,9 @@
         "tags": [
           "agents"
         ],
-        "summary": "DELETE /v1/orgs/{org}/agents/{agent_id} - Archive agent",
+        "summary": "DELETE /v1/agents/{agent_id} - Archive agent",
         "operationId": "delete_agent",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "path",
@@ -268,18 +217,9 @@
         "tags": [
           "agents"
         ],
-        "summary": "PATCH /v1/orgs/{org}/agents/{agent_id} - Update agent",
+        "summary": "PATCH /v1/agents/{agent_id} - Update agent",
         "operationId": "update_agent",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "path",
@@ -344,23 +284,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/agents/{agent_id}/export": {
+    "/v1/agents/{agent_id}/export": {
       "get": {
         "tags": [
           "agents"
         ],
-        "summary": "GET /v1/orgs/{org}/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter",
+        "summary": "GET /v1/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter",
         "operationId": "export_agent",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "path",
@@ -390,24 +321,13 @@
         }
       }
     },
-    "/v1/orgs/{org}/capabilities": {
+    "/v1/capabilities": {
       "get": {
         "tags": [
           "capabilities"
         ],
-        "summary": "GET /v1/orgs/{org}/capabilities - List all available capabilities",
+        "summary": "GET /v1/capabilities - List all available capabilities",
         "operationId": "list_capabilities",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "List of available capabilities",
@@ -422,23 +342,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/capabilities/{capability_id}": {
+    "/v1/capabilities/{capability_id}": {
       "get": {
         "tags": [
           "capabilities"
         ],
-        "summary": "GET /v1/orgs/{org}/capabilities/{capability_id} - Get a specific capability",
+        "summary": "GET /v1/capabilities/{capability_id} - Get a specific capability",
         "operationId": "get_capability",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "capability_id",
             "in": "path",
@@ -466,7 +377,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-models": {
+    "/v1/llm-models": {
       "get": {
         "tags": [
           "llm-models"
@@ -474,15 +385,6 @@
         "summary": "List all models across all providers",
         "operationId": "list_all_models",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "source",
             "in": "query",
@@ -532,7 +434,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-models/{id}": {
+    "/v1/llm-models/{id}": {
       "get": {
         "tags": [
           "llm-models"
@@ -540,15 +442,6 @@
         "summary": "Get a specific model with provider info and profile",
         "operationId": "get_model",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "id",
             "in": "path",
@@ -586,15 +479,6 @@
         "operationId": "delete_model",
         "parameters": [
           {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "id",
             "in": "path",
             "description": "Model ID (prefixed, e.g., mod_...)",
@@ -623,15 +507,6 @@
         "summary": "Update a model",
         "operationId": "update_model",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "id",
             "in": "path",
@@ -672,24 +547,13 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-providers": {
+    "/v1/llm-providers": {
       "get": {
         "tags": [
           "llm-providers"
         ],
         "summary": "List all LLM providers",
         "operationId": "list_providers",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "List of providers",
@@ -709,17 +573,6 @@
         ],
         "summary": "Create a new LLM provider",
         "operationId": "create_provider",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -750,7 +603,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-providers/{id}": {
+    "/v1/llm-providers/{id}": {
       "get": {
         "tags": [
           "llm-providers"
@@ -758,15 +611,6 @@
         "summary": "Get a specific LLM provider",
         "operationId": "get_provider",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "id",
             "in": "path",
@@ -804,15 +648,6 @@
         "operationId": "delete_provider",
         "parameters": [
           {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "id",
             "in": "path",
             "description": "Provider ID (prefixed, e.g., prov_...)",
@@ -841,15 +676,6 @@
         "summary": "Update an LLM provider",
         "operationId": "update_provider",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "id",
             "in": "path",
@@ -890,7 +716,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-providers/{provider_id}/models": {
+    "/v1/llm-providers/{provider_id}/models": {
       "get": {
         "tags": [
           "llm-models"
@@ -898,15 +724,6 @@
         "summary": "List models for a specific provider",
         "operationId": "list_provider_models",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "provider_id",
             "in": "path",
@@ -940,15 +757,6 @@
         "summary": "Create a new model for a provider",
         "operationId": "create_model",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "provider_id",
             "in": "path",
@@ -989,24 +797,13 @@
         }
       }
     },
-    "/v1/orgs/{org}/mcp-servers": {
+    "/v1/mcp-servers": {
       "get": {
         "tags": [
           "mcp-servers"
         ],
-        "summary": "GET /v1/orgs/{org}/mcp-servers - List all MCP servers",
+        "summary": "GET /v1/mcp-servers - List all MCP servers",
         "operationId": "list_mcp_servers",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "List of MCP servers",
@@ -1027,19 +824,8 @@
         "tags": [
           "mcp-servers"
         ],
-        "summary": "POST /v1/orgs/{org}/mcp-servers - Create a new MCP server",
+        "summary": "POST /v1/mcp-servers - Create a new MCP server",
         "operationId": "create_mcp_server",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1084,23 +870,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/mcp-servers/{server_id}": {
+    "/v1/mcp-servers/{server_id}": {
       "get": {
         "tags": [
           "mcp-servers"
         ],
-        "summary": "GET /v1/orgs/{org}/mcp-servers/{server_id} - Get MCP server by ID",
+        "summary": "GET /v1/mcp-servers/{server_id} - Get MCP server by ID",
         "operationId": "get_mcp_server",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "server_id",
             "in": "path",
@@ -1137,18 +914,9 @@
         "tags": [
           "mcp-servers"
         ],
-        "summary": "DELETE /v1/orgs/{org}/mcp-servers/{server_id} - Delete MCP server",
+        "summary": "DELETE /v1/mcp-servers/{server_id} - Delete MCP server",
         "operationId": "delete_mcp_server",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "server_id",
             "in": "path",
@@ -1178,18 +946,9 @@
         "tags": [
           "mcp-servers"
         ],
-        "summary": "PATCH /v1/orgs/{org}/mcp-servers/{server_id} - Update MCP server",
+        "summary": "PATCH /v1/mcp-servers/{server_id} - Update MCP server",
         "operationId": "update_mcp_server",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "server_id",
             "in": "path",
@@ -1254,23 +1013,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions": {
+    "/v1/sessions": {
       "get": {
         "tags": [
           "sessions"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions - List sessions in organization",
+        "summary": "GET /v1/sessions - List sessions in organization",
         "operationId": "list_sessions",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "query",
@@ -1336,19 +1086,8 @@
         "tags": [
           "sessions"
         ],
-        "summary": "POST /v1/orgs/{org}/sessions - Create a new session",
+        "summary": "POST /v1/sessions - Create a new session",
         "operationId": "create_session",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1379,23 +1118,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}": {
+    "/v1/sessions/{session_id}": {
       "get": {
         "tags": [
           "sessions"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions/{session_id} - Get session",
+        "summary": "GET /v1/sessions/{session_id} - Get session",
         "operationId": "get_session",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1432,18 +1162,9 @@
         "tags": [
           "sessions"
         ],
-        "summary": "DELETE /v1/orgs/{org}/sessions/{session_id} - Delete session",
+        "summary": "DELETE /v1/sessions/{session_id} - Delete session",
         "operationId": "delete_session",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1473,18 +1194,9 @@
         "tags": [
           "sessions"
         ],
-        "summary": "PATCH /v1/orgs/{org}/sessions/{session_id} - Update session",
+        "summary": "PATCH /v1/sessions/{session_id} - Update session",
         "operationId": "update_session",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1528,24 +1240,15 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/cancel": {
+    "/v1/sessions/{session_id}/cancel": {
       "post": {
         "tags": [
           "sessions"
         ],
-        "summary": "POST /v1/orgs/{org}/sessions/{session_id}/cancel - Cancel current turn",
+        "summary": "POST /v1/sessions/{session_id}/cancel - Cancel current turn",
         "description": "Cancels the currently running turn in the session. If no turn is running,\nthis is a no-op and returns success (idempotent). When a turn is active:\n1. Cancel the underlying workflow execution\n2. Emit a turn.cancelled event\n3. Insert an agent message indicating the turn was cancelled\n4. Set the session status back to idle",
         "operationId": "cancel_turn",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1579,23 +1282,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/events": {
+    "/v1/sessions/{session_id}/events": {
       "get": {
         "tags": [
           "events"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions/{session_id}/events - List events (JSON)",
+        "summary": "GET /v1/sessions/{session_id}/events - List events (JSON)",
         "operationId": "list_events",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1656,7 +1350,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs": {
+    "/v1/sessions/{session_id}/fs": {
       "get": {
         "tags": [
           "filesystem"
@@ -1664,15 +1358,6 @@
         "summary": "GET /fs - Get root directory listing",
         "operationId": "get_root",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1705,7 +1390,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/_/copy": {
+    "/v1/sessions/{session_id}/fs/_/copy": {
       "post": {
         "tags": [
           "filesystem"
@@ -1713,15 +1398,6 @@
         "summary": "POST /fs/_/copy - Copy file",
         "operationId": "copy_file",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1768,7 +1444,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/_/grep": {
+    "/v1/sessions/{session_id}/fs/_/grep": {
       "post": {
         "tags": [
           "filesystem"
@@ -1776,15 +1452,6 @@
         "summary": "POST /fs/_/grep - Search files",
         "operationId": "grep_files",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1825,7 +1492,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/_/move": {
+    "/v1/sessions/{session_id}/fs/_/move": {
       "post": {
         "tags": [
           "filesystem"
@@ -1833,15 +1500,6 @@
         "summary": "POST /fs/_/move - Move/rename file",
         "operationId": "move_file",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1888,7 +1546,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/_/stat": {
+    "/v1/sessions/{session_id}/fs/_/stat": {
       "post": {
         "tags": [
           "filesystem"
@@ -1896,15 +1554,6 @@
         "summary": "POST /fs/_/stat - Get file or directory stat",
         "operationId": "stat_file",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1948,7 +1597,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/{path}": {
+    "/v1/sessions/{session_id}/fs/{path}": {
       "get": {
         "tags": [
           "filesystem"
@@ -1956,15 +1605,6 @@
         "summary": "GET /fs/*path - Get file content or directory listing",
         "operationId": "get_path",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -2015,15 +1655,6 @@
         "summary": "PUT /fs/*path - Update file content",
         "operationId": "update_path",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -2083,15 +1714,6 @@
         "operationId": "create_path",
         "parameters": [
           {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "session_id",
             "in": "path",
             "description": "Session ID (prefixed, e.g., sess_...)",
@@ -2150,15 +1772,6 @@
         "operationId": "delete_path",
         "parameters": [
           {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "session_id",
             "in": "path",
             "description": "Session ID (prefixed, e.g., sess_...)",
@@ -2206,23 +1819,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/messages": {
+    "/v1/sessions/{session_id}/messages": {
       "get": {
         "tags": [
           "messages"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions/{session_id}/messages - List messages (PRIMARY data)",
+        "summary": "GET /v1/sessions/{session_id}/messages - List messages (PRIMARY data)",
         "operationId": "list_messages",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -2259,18 +1863,9 @@
         "tags": [
           "messages"
         ],
-        "summary": "POST /v1/orgs/{org}/sessions/{session_id}/messages - Create message (user message triggers workflow)",
+        "summary": "POST /v1/sessions/{session_id}/messages - Create message (user message triggers workflow)",
         "operationId": "create_message",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -2314,23 +1909,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/sse": {
+    "/v1/sessions/{session_id}/sse": {
       "get": {
         "tags": [
           "events"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions/{session_id}/sse - Stream events (SSE notifications)",
+        "summary": "GET /v1/sessions/{session_id}/sse - Stream events (SSE notifications)",
         "operationId": "stream_sse",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -3367,10 +2953,6 @@
           },
           {
             "$ref": "#/components/schemas/SessionIdledData"
-          },
-          {
-            "type": "object",
-            "description": "Raw data for backward compatibility with legacy events"
           }
         ],
         "title": "EventData",

--- a/python/README.md
+++ b/python/README.md
@@ -16,7 +16,7 @@ from everruns_sdk import Everruns
 
 async def main():
     # Uses EVERRUNS_API_KEY environment variable
-    client = Everruns(org="my-org")
+    client = Everruns()
     
     # Create an agent
     agent = await client.agents.create(

--- a/python/everruns_sdk/__init__.py
+++ b/python/everruns_sdk/__init__.py
@@ -4,7 +4,7 @@ A typed client for the Everruns API.
 
 Quick Start:
     >>> from everruns_sdk import Everruns
-    >>> client = Everruns(org="my-org")  # uses EVERRUNS_API_KEY
+    >>> client = Everruns()  # uses EVERRUNS_API_KEY
     >>> agent = await client.agents.create("Assistant", "You are helpful.")
 """
 

--- a/python/everruns_sdk/client.py
+++ b/python/everruns_sdk/client.py
@@ -30,18 +30,16 @@ class Everruns:
     """Main client for interacting with the Everruns API.
 
     Args:
-        org: Organization ID
         api_key: API key (optional, defaults to EVERRUNS_API_KEY env var)
         base_url: Base URL for the API (optional)
 
     Example:
-        >>> client = Everruns(org="my-org")
+        >>> client = Everruns()
         >>> agent = await client.agents.create("Assistant", "You are helpful.")
     """
 
     def __init__(
         self,
-        org: str,
         api_key: Optional[str] = None,
         base_url: str = DEFAULT_BASE_URL,
     ):
@@ -54,7 +52,6 @@ class Everruns:
                 )
 
         self._api_key = ApiKey(api_key)
-        self._org = org
         self._base_url = base_url.rstrip("/")
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
@@ -86,7 +83,7 @@ class Everruns:
         return EventsClient(self)
 
     def _url(self, path: str) -> str:
-        return f"/v1/orgs/{self._org}{path}"
+        return f"/v1{path}"
 
     async def _get(self, path: str) -> Any:
         resp = await self._client.get(self._url(path))

--- a/python/everruns_sdk/sse.py
+++ b/python/everruns_sdk/sse.py
@@ -54,8 +54,7 @@ class EventStream:
     def _build_url(self) -> str:
         """Build the SSE URL with query parameters."""
         base = self._client._base_url
-        org = self._client._org
-        url = f"{base}/v1/orgs/{org}/sessions/{self._session_id}/sse"
+        url = f"{base}/v1/sessions/{self._session_id}/sse"
         params = []
 
         since_id = self._last_event_id or self._options.since_id

--- a/python/examples/basic.py
+++ b/python/examples/basic.py
@@ -7,7 +7,7 @@ from everruns_sdk import Everruns
 
 async def main():
     # Initialize client from environment
-    client = Everruns(org="my-org")
+    client = Everruns()
 
     try:
         # Create an agent

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -41,16 +41,16 @@ def test_api_key_from_env_missing():
 
 def test_client_creation():
     """Test client creation with explicit API key."""
-    client = Everruns(org="test-org", api_key="evr_test_key")
-    assert client._org == "test-org"
+    client = Everruns(api_key="evr_test_key")
+    assert client._api_key.value == "evr_test_key"
 
 
 def test_client_from_env():
     """Test client creation from environment variable."""
     os.environ["EVERRUNS_API_KEY"] = "evr_from_env"
     try:
-        client = Everruns(org="test-org")
-        assert client._org == "test-org"
+        client = Everruns()
+        assert client._api_key.value == "evr_from_env"
     finally:
         del os.environ["EVERRUNS_API_KEY"]
 
@@ -61,4 +61,4 @@ def test_client_missing_api_key():
         del os.environ["EVERRUNS_API_KEY"]
 
     with pytest.raises(ValueError):
-        Everruns(org="test-org")
+        Everruns()

--- a/rust/README.md
+++ b/rust/README.md
@@ -19,7 +19,7 @@ use everruns_sdk::Everruns;
 #[tokio::main]
 async fn main() -> Result<(), everruns_sdk::Error> {
     // Uses EVERRUNS_API_KEY environment variable
-    let client = Everruns::from_env("my-org")?;
+    let client = Everruns::from_env()?;
 
     // Create an agent
     let agent = client.agents().create(
@@ -43,10 +43,10 @@ The SDK uses API key authentication. Set the \`EVERRUNS_API_KEY\` environment va
 
 \`\`\`rust
 // From environment variable
-let client = Everruns::from_env("my-org")?;
+let client = Everruns::from_env()?;
 
 // Explicit key
-let client = Everruns::new("evr_...", "my-org");
+let client = Everruns::new("evr_...")?;
 \`\`\`
 
 ## Streaming Events

--- a/rust/examples/basic.rs
+++ b/rust/examples/basic.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // Initialize client from environment
-    let client = Everruns::from_env("my-org")?;
+    let client = Everruns::from_env()?;
 
     // Create an agent
     let agent = client

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -14,41 +14,32 @@ pub struct Everruns {
     http: reqwest::Client,
     base_url: Url,
     api_key: ApiKey,
-    org: String,
 }
 
 impl Everruns {
     /// Create a new client with explicit API key
-    pub fn new(api_key: impl Into<String>, org: impl Into<String>) -> Result<Self> {
-        Self::with_base_url(api_key, org, DEFAULT_BASE_URL)
+    pub fn new(api_key: impl Into<String>) -> Result<Self> {
+        Self::with_base_url(api_key, DEFAULT_BASE_URL)
     }
 
     /// Create a new client using EVERRUNS_API_KEY environment variable
-    pub fn from_env(org: impl Into<String>) -> Result<Self> {
+    pub fn from_env() -> Result<Self> {
         let api_key = ApiKey::from_env()?;
-        Self::with_api_key(api_key, org)
+        Self::with_api_key(api_key)
     }
 
     /// Create a new client with a custom base URL
-    pub fn with_base_url(
-        api_key: impl Into<String>,
-        org: impl Into<String>,
-        base_url: &str,
-    ) -> Result<Self> {
+    pub fn with_base_url(api_key: impl Into<String>, base_url: &str) -> Result<Self> {
         let api_key = ApiKey::new(api_key);
-        Self::with_api_key_and_url(api_key, org, base_url)
+        Self::with_api_key_and_url(api_key, base_url)
     }
 
     /// Create a new client with an ApiKey instance
-    pub fn with_api_key(api_key: ApiKey, org: impl Into<String>) -> Result<Self> {
-        Self::with_api_key_and_url(api_key, org, DEFAULT_BASE_URL)
+    pub fn with_api_key(api_key: ApiKey) -> Result<Self> {
+        Self::with_api_key_and_url(api_key, DEFAULT_BASE_URL)
     }
 
-    fn with_api_key_and_url(
-        api_key: ApiKey,
-        org: impl Into<String>,
-        base_url: &str,
-    ) -> Result<Self> {
+    fn with_api_key_and_url(api_key: ApiKey, base_url: &str) -> Result<Self> {
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()?;
@@ -59,7 +50,6 @@ impl Everruns {
             http,
             base_url,
             api_key,
-            org: org.into(),
         })
     }
 
@@ -84,7 +74,7 @@ impl Everruns {
     }
 
     fn url(&self, path: &str) -> Url {
-        let full_path = format!("/v1/orgs/{}{}", self.org, path);
+        let full_path = format!("/v1{}", path);
         self.base_url.join(&full_path).expect("valid URL")
     }
 
@@ -355,7 +345,6 @@ impl std::fmt::Debug for Everruns {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Everruns")
             .field("base_url", &self.base_url.as_str())
-            .field("org", &self.org)
             .field("api_key", &self.api_key)
             .finish()
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -10,7 +10,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), everruns_sdk::Error> {
 //!     // Uses EVERRUNS_API_KEY environment variable
-//!     let client = Everruns::from_env("my-org")?;
+//!     let client = Everruns::from_env()?;
 //!
 //!     // Create an agent
 //!     let agent = client.agents().create(

--- a/rust/tests/client_test.rs
+++ b/rust/tests/client_test.rs
@@ -4,7 +4,7 @@ use everruns_sdk::Everruns;
 
 #[test]
 fn test_client_creation() {
-    let result = Everruns::new("evr_test_key", "test-org");
+    let result = Everruns::new("evr_test_key");
     assert!(result.is_ok());
 }
 
@@ -13,13 +13,12 @@ fn test_client_from_env_missing() {
     // Ensure env var is not set
     // SAFETY: This test runs single-threaded and only removes a test-specific env var
     unsafe { std::env::remove_var("EVERRUNS_API_KEY") };
-    let result = Everruns::from_env("test-org");
+    let result = Everruns::from_env();
     assert!(result.is_err());
 }
 
 #[test]
 fn test_custom_base_url() {
-    let result =
-        Everruns::with_base_url("evr_test_key", "test-org", "https://custom.example.com/api");
+    let result = Everruns::with_base_url("evr_test_key", "https://custom.example.com/api");
     assert!(result.is_ok());
 }

--- a/specs/api-surface.md
+++ b/specs/api-surface.md
@@ -7,33 +7,33 @@ SDKs cover agents and sessions functionality. No durable execution endpoints.
 ## Covered Endpoints
 
 ### Agents
-- `POST /v1/orgs/{org}/agents` - Create agent
-- `GET /v1/orgs/{org}/agents` - List agents
-- `GET /v1/orgs/{org}/agents/{id}` - Get agent
-- `PATCH /v1/orgs/{org}/agents/{id}` - Update agent
-- `DELETE /v1/orgs/{org}/agents/{id}` - Archive agent
+- `POST /v1/agents` - Create agent
+- `GET /v1/agents` - List agents
+- `GET /v1/agents/{id}` - Get agent
+- `PATCH /v1/agents/{id}` - Update agent
+- `DELETE /v1/agents/{id}` - Archive agent
 
 ### Sessions
-- `POST /v1/orgs/{org}/sessions` - Create session
-- `GET /v1/orgs/{org}/sessions` - List sessions
-- `GET /v1/orgs/{org}/sessions/{id}` - Get session
-- `PATCH /v1/orgs/{org}/sessions/{id}` - Update session
-- `DELETE /v1/orgs/{org}/sessions/{id}` - Delete session
-- `POST /v1/orgs/{org}/sessions/{id}/cancel` - Cancel turn
+- `POST /v1/sessions` - Create session
+- `GET /v1/sessions` - List sessions
+- `GET /v1/sessions/{id}` - Get session
+- `PATCH /v1/sessions/{id}` - Update session
+- `DELETE /v1/sessions/{id}` - Delete session
+- `POST /v1/sessions/{id}/cancel` - Cancel turn
 
 ### Messages
-- `POST /v1/orgs/{org}/sessions/{id}/messages` - Create message
-- `GET /v1/orgs/{org}/sessions/{id}/messages` - List messages
+- `POST /v1/sessions/{id}/messages` - Create message
+- `GET /v1/sessions/{id}/messages` - List messages
 
 ### Events
-- `GET /v1/orgs/{org}/sessions/{id}/events` - List events (polling)
-- `GET /v1/orgs/{org}/sessions/{id}/sse` - SSE stream
+- `GET /v1/sessions/{id}/events` - List events (polling)
+- `GET /v1/sessions/{id}/sse` - SSE stream
 
 ### Images
-- `POST /v1/orgs/{org}/images` - Upload image
-- `GET /v1/orgs/{org}/images/{id}` - Get image
+- `POST /v1/images` - Upload image
+- `GET /v1/images/{id}` - Get image
 
 ### Session Filesystem
-- `GET /v1/orgs/{org}/sessions/{id}/fs` - List files
-- `GET /v1/orgs/{org}/sessions/{id}/fs/{path}` - Read file
-- `PUT /v1/orgs/{org}/sessions/{id}/fs/{path}` - Write file
+- `GET /v1/sessions/{id}/fs` - List files
+- `GET /v1/sessions/{id}/fs/{path}` - Read file
+- `PUT /v1/sessions/{id}/fs/{path}` - Write file

--- a/specs/sdk-features.md
+++ b/specs/sdk-features.md
@@ -12,7 +12,6 @@ Everruns SDKs provide typed clients for the Everruns API. All language implement
 
 | Parameter | Env Variable | Description |
 |-----------|--------------|-------------|
-| `org` | `EVERRUNS_ORG` | Organization ID |
 | `api_key` | `EVERRUNS_API_KEY` | API key |
 | `api_url` | `EVERRUNS_API_URL` | API base URL (optional, for testing/self-hosted) |
 
@@ -21,17 +20,14 @@ All parameters can be omitted if the corresponding environment variable is set.
 ### Initialization Patterns
 
 ```
-# From environment (recommended) - all params from env vars
+# From environment (recommended) - api_key from env var
 client = Everruns()
 
-# Explicit org (api_key from env)
-client = Everruns(org="my-org")
-
 # Explicit API key
-client = Everruns(org="my-org", api_key="evr_...")
+client = Everruns(api_key="evr_...")
 
 # Custom base URL
-client = Everruns(org="my-org", api_url="https://custom.example.com/api")
+client = Everruns(api_url="https://custom.example.com/api")
 ```
 
 ## Resource Sub-Clients

--- a/specs/sse-streaming.md
+++ b/specs/sse-streaming.md
@@ -3,7 +3,7 @@
 ## Connection
 
 ```
-GET /v1/orgs/{org}/sessions/{id}/sse
+GET /v1/sessions/{id}/sse
 Accept: text/event-stream
 ```
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -14,7 +14,7 @@ npm install @everruns/sdk
 import { Everruns } from "@everruns/sdk";
 
 // Uses EVERRUNS_API_KEY environment variable
-const client = Everruns.fromEnv("my-org");
+const client = Everruns.fromEnv();
 
 // Create an agent
 const agent = await client.agents.create({
@@ -40,12 +40,11 @@ The SDK uses API key authentication. Set the \`EVERRUNS_API_KEY\` environment va
 
 \`\`\`typescript
 // From environment variable
-const client = Everruns.fromEnv("my-org");
+const client = Everruns.fromEnv();
 
 // Explicit key
 const client = new Everruns({
-  apiKey: "evr_...",
-  org: "my-org"
+  apiKey: "evr_..."
 });
 \`\`\`
 

--- a/typescript/examples/basic.ts
+++ b/typescript/examples/basic.ts
@@ -9,7 +9,7 @@ import { Everruns } from "@everruns/sdk";
 
 async function main() {
   // Create client using EVERRUNS_API_KEY env var
-  const client = Everruns.fromEnv("my-org");
+  const client = Everruns.fromEnv();
 
   // Create an agent
   const agent = await client.agents.create({

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -17,13 +17,11 @@ import { EventStream } from "./sse.js";
 
 export interface EverrunsOptions {
   apiKey?: string | ApiKey;
-  org: string;
   baseUrl?: string;
 }
 
 export class Everruns {
   private readonly apiKey: ApiKey;
-  private readonly org: string;
   private readonly baseUrl: string;
 
   readonly agents: AgentsClient;
@@ -31,7 +29,7 @@ export class Everruns {
   readonly messages: MessagesClient;
   readonly events: EventsClient;
 
-  constructor(options: EverrunsOptions) {
+  constructor(options: EverrunsOptions = {}) {
     if (options.apiKey instanceof ApiKey) {
       this.apiKey = options.apiKey;
     } else if (options.apiKey) {
@@ -39,7 +37,6 @@ export class Everruns {
     } else {
       this.apiKey = ApiKey.fromEnv();
     }
-    this.org = options.org;
     this.baseUrl = options.baseUrl ?? "https://api.everruns.com";
 
     this.agents = new AgentsClient(this);
@@ -51,12 +48,12 @@ export class Everruns {
   /**
    * Create a client using the EVERRUNS_API_KEY environment variable.
    */
-  static fromEnv(org: string, baseUrl?: string): Everruns {
-    return new Everruns({ org, baseUrl });
+  static fromEnv(baseUrl?: string): Everruns {
+    return new Everruns({ baseUrl });
   }
 
   async fetch<T>(path: string, options: RequestInit = {}): Promise<T> {
-    const url = `${this.baseUrl}/orgs/${this.org}${path}`;
+    const url = `${this.baseUrl}${path}`;
     const response = await fetch(url, {
       ...options,
       headers: {
@@ -89,7 +86,7 @@ export class Everruns {
   }
 
   getStreamUrl(path: string): string {
-    return `${this.baseUrl}/orgs/${this.org}${path}`;
+    return `${this.baseUrl}${path}`;
   }
 
   getAuthHeader(): string {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,7 +6,7 @@
  * import { Everruns } from "@everruns/sdk";
  *
  * // Uses EVERRUNS_API_KEY environment variable
- * const client = Everruns.fromEnv("my-org");
+ * const client = Everruns.fromEnv();
  *
  * // Create an agent
  * const agent = await client.agents.create({

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -17,7 +17,6 @@ describe("Everruns", () => {
   it("should create client with explicit key", () => {
     const client = new Everruns({
       apiKey: "evr_test_key",
-      org: "test-org",
     });
     expect(client).toBeDefined();
     expect(client.agents).toBeDefined();
@@ -30,7 +29,6 @@ describe("Everruns", () => {
     const apiKey = new ApiKey("evr_test_key");
     const client = new Everruns({
       apiKey,
-      org: "test-org",
     });
     expect(client).toBeDefined();
   });
@@ -38,11 +36,8 @@ describe("Everruns", () => {
   it("should use custom base URL", () => {
     const client = new Everruns({
       apiKey: "evr_test_key",
-      org: "test-org",
       baseUrl: "https://custom.api.com",
     });
-    expect(client.getStreamUrl("/test")).toBe(
-      "https://custom.api.com/orgs/test-org/test"
-    );
+    expect(client.getStreamUrl("/test")).toBe("https://custom.api.com/test");
   });
 });


### PR DESCRIPTION
## Summary
- Update OpenAPI spec from everruns/everruns (orgs removed from API paths)
- Remove `org` parameter from all SDK clients (Rust, Python, TypeScript)
- Update specs, docs, examples, tests, and cookbooks
- Remove `EVERRUNS_ORG` environment variable references

## Test plan
- [x] All Rust tests pass
- [x] All Python tests pass
- [x] All TypeScript tests pass
- [x] Cookbook compiles
- [ ] CI passes