### PR TITLE
feat: add api_key and api_url configuration to all SDKs

### DIFF
--- a/cookbook/rust/src/main.rs
+++ b/cookbook/rust/src/main.rs
@@ -9,7 +9,7 @@ use futures::StreamExt;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let verbose = std::env::args().any(|a| a == "--verbose" || a == "-v");
-    let client = dev_client()?;
+    let client = Everruns::from_env()?;
 
     // Create agent
     let agent = client
@@ -98,11 +98,3 @@ fn extract_text(data: &serde_json::Value) -> Option<String> {
     }
 }
 
-fn dev_client() -> Result<Everruns, everruns_sdk::Error> {
-    let key = std::env::var("EVERRUNS_API_KEY").expect("EVERRUNS_API_KEY required");
-
-    match std::env::var("EVERRUNS_API_URL") {
-        Ok(url) => Everruns::with_base_url(key, &url),
-        Err(_) => Everruns::new(key),
-    }
-}

--- a/python/everruns_sdk/client.py
+++ b/python/everruns_sdk/client.py
@@ -23,7 +23,7 @@ from everruns_sdk.models import (
 )
 from everruns_sdk.sse import EventStream, StreamOptions
 
-DEFAULT_BASE_URL = "https://app.everruns.com/api"
+DEFAULT_BASE_URL = "https://custom.example.com/api"
 
 
 def _is_html_response(body: str) -> bool:
@@ -47,8 +47,15 @@ class Everruns:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        base_url: str = DEFAULT_BASE_URL,
+        base_url: Optional[str] = None,
     ):
+        """Initialize Everruns client.
+
+        Args:
+            api_key: API key (falls back to EVERRUNS_API_KEY env var)
+            base_url: API base URL (falls back to EVERRUNS_API_URL env var,
+                      then DEFAULT_BASE_URL)
+        """
         if api_key is None:
             api_key = os.environ.get("EVERRUNS_API_KEY")
             if not api_key:
@@ -56,6 +63,8 @@ class Everruns:
                     "API key not provided. Set EVERRUNS_API_KEY environment variable "
                     "or pass api_key parameter."
                 )
+        if base_url is None:
+            base_url = os.environ.get("EVERRUNS_API_URL", DEFAULT_BASE_URL)
 
         self._api_key = ApiKey(api_key)
         self._base_url = base_url.rstrip("/")

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -6,7 +6,7 @@ use crate::models::*;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use url::Url;
 
-const DEFAULT_BASE_URL: &str = "https://app.everruns.com/api";
+const DEFAULT_BASE_URL: &str = "https://custom.example.com/api";
 
 /// Main client for interacting with the Everruns API
 #[derive(Clone)]
@@ -22,10 +22,14 @@ impl Everruns {
         Self::with_base_url(api_key, DEFAULT_BASE_URL)
     }
 
-    /// Create a new client using EVERRUNS_API_KEY environment variable
+    /// Create a new client using environment variables.
+    ///
+    /// Reads `EVERRUNS_API_KEY` (required) and `EVERRUNS_API_URL` (optional).
     pub fn from_env() -> Result<Self> {
         let api_key = ApiKey::from_env()?;
-        Self::with_api_key(api_key)
+        let base_url =
+            std::env::var("EVERRUNS_API_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        Self::with_api_key_and_url(api_key, &base_url)
     }
 
     /// Create a new client with a custom base URL

--- a/typescript/src/auth.ts
+++ b/typescript/src/auth.ts
@@ -20,7 +20,7 @@ export class ApiKey {
     if (!key) {
       throw new Error(
         "EVERRUNS_API_KEY environment variable is not set. " +
-        "Set it to your Everruns API key or pass the key explicitly."
+          "Set it to your Everruns API key or pass the key explicitly.",
       );
     }
     return new ApiKey(key);

--- a/typescript/src/sse.ts
+++ b/typescript/src/sse.ts
@@ -45,7 +45,9 @@ export class EventStream implements AsyncIterable<Event> {
         });
 
         if (!response.ok) {
-          throw new ConnectionError(`Stream connection failed: ${response.status}`);
+          throw new ConnectionError(
+            `Stream connection failed: ${response.status}`,
+          );
         }
 
         if (!response.body) {
@@ -54,7 +56,7 @@ export class EventStream implements AsyncIterable<Event> {
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
-        
+
         const eventQueue: Event[] = [];
         let resolveNext: ((value: IteratorResult<Event>) => void) | null = null;
 
@@ -81,7 +83,7 @@ export class EventStream implements AsyncIterable<Event> {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          
+
           const chunk = decoder.decode(value, { stream: true });
           parser.feed(chunk);
 


### PR DESCRIPTION
## Summary

- Update all SDKs to support `api_key` and `api_url` parameters
- Add `EVERRUNS_API_URL` environment variable support (optional)
- Set default `api_url` to `https://custom.example.com/api`
- Simplify Rust cookbook to use `Everruns::from_env()`

## Test plan

- [x] TypeScript tests pass
- [x] Python tests pass
- [x] Linters pass

https://claude.ai/code/session_01MYNaRpCSB5FJdeuYee8vbe