### PR TITLE
fix: correct URL joining across all SDKs

### DIFF
--- a/python/everruns_sdk/sse.py
+++ b/python/everruns_sdk/sse.py
@@ -53,7 +53,8 @@ class EventStream:
 
     def _build_url(self) -> str:
         """Build the SSE URL with query parameters."""
-        base = self._client._base_url
+        # base_url already has trailing slash, use relative path
+        base = self._client._base_url.rstrip("/")
         url = f"{base}/v1/sessions/{self._session_id}/sse"
         params = []
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -62,3 +62,24 @@ def test_client_missing_api_key():
 
     with pytest.raises(ValueError):
         Everruns()
+
+
+def test_base_url_normalization_adds_trailing_slash():
+    """Test that base URL without trailing slash gets one added."""
+    client = Everruns(api_key="evr_test_key", base_url="https://custom.example.com/api")
+    # Base URL should have trailing slash for correct URL joining
+    assert client._base_url == "https://custom.example.com/api/"
+
+
+def test_base_url_normalization_preserves_single_trailing_slash():
+    """Test that base URL with trailing slash is normalized correctly."""
+    client = Everruns(api_key="evr_test_key", base_url="https://custom.example.com/api/")
+    assert client._base_url == "https://custom.example.com/api/"
+
+
+def test_url_path_construction():
+    """Test that URL paths are constructed correctly."""
+    client = Everruns(api_key="evr_test_key", base_url="https://custom.example.com/api")
+    # The _url method should produce relative paths without leading slash
+    assert client._url("/agents") == "v1/agents"
+    assert client._url("/sessions/123") == "v1/sessions/123"

--- a/rust/tests/client_test.rs
+++ b/rust/tests/client_test.rs
@@ -22,3 +22,31 @@ fn test_custom_base_url() {
     let result = Everruns::with_base_url("evr_test_key", "https://custom.example.com/api");
     assert!(result.is_ok());
 }
+
+#[test]
+fn test_base_url_normalization_adds_trailing_slash() {
+    // Base URL without trailing slash should be normalized to have one
+    let client = Everruns::with_base_url("evr_test_key", "https://custom.example.com/api")
+        .expect("client creation should succeed");
+
+    // Debug output includes the base_url field
+    let debug_str = format!("{:?}", client);
+    // The base URL should have a trailing slash after normalization
+    assert!(
+        debug_str.contains("https://custom.example.com/api/"),
+        "base URL should be normalized with trailing slash"
+    );
+}
+
+#[test]
+fn test_base_url_normalization_preserves_trailing_slash() {
+    // Base URL with trailing slash should remain unchanged
+    let client = Everruns::with_base_url("evr_test_key", "https://custom.example.com/api/")
+        .expect("client creation should succeed");
+
+    let debug_str = format!("{:?}", client);
+    assert!(
+        debug_str.contains("https://custom.example.com/api/"),
+        "base URL with trailing slash should be preserved"
+    );
+}

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -34,3 +34,43 @@ Everruns SDKs provide typed clients for the Everruns API across multiple languag
 ├── examples/
 └── tests/
 ```
+
+## URL Joining
+
+All SDKs normalize base URLs and paths to ensure correct URL construction:
+
+### The Problem
+
+RFC 3986 URL joining has a common pitfall:
+- Without trailing slash on base: `http://host/api` + `v1/agents` = `http://host/v1/agents` (loses `/api`)
+- With trailing slash on base: `http://host/api/` + `v1/agents` = `http://host/api/v1/agents` (correct)
+
+### The Solution
+
+Each SDK normalizes URLs at client construction:
+
+| SDK | Base URL | Path Format | Strategy |
+|-----|----------|-------------|----------|
+| Rust | Add trailing `/` | `v1/{path}` (relative) | `Url::join()` with normalized base |
+| Python | Add trailing `/` | `v1/{path}` (relative) | httpx `base_url` param |
+| TypeScript | Remove trailing `/` | `/v1/{path}` (absolute) | String concatenation |
+
+### Implementation Pattern
+
+```
+// Rust/Python: ensure trailing slash, use relative paths
+base = "http://host/api/"  // normalized
+path = "v1/agents"         // no leading slash
+result = join(base, path)  // "http://host/api/v1/agents"
+
+// TypeScript: remove trailing slash, use absolute paths
+base = "http://host/api"   // normalized (no trailing slash)
+path = "/v1/agents"        // with leading slash
+result = base + path       // "http://host/api/v1/agents"
+```
+
+### Testing Custom Base URLs
+
+When testing with custom base URLs (e.g., `http://localhost:8080/api`):
+- Rust/Python: Works regardless of trailing slash (normalized internally)
+- TypeScript: Works regardless of trailing slash (normalized internally)

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -38,6 +38,18 @@ describe("Everruns", () => {
       apiKey: "evr_test_key",
       baseUrl: "https://custom.api.com",
     });
-    expect(client.getStreamUrl("/test")).toBe("https://custom.api.com/test");
+    // URLs include the /v1 prefix for API versioning
+    expect(client.getStreamUrl("/test")).toBe("https://custom.api.com/v1/test");
+  });
+
+  it("should normalize base URL with trailing slash", () => {
+    const client = new Everruns({
+      apiKey: "evr_test_key",
+      baseUrl: "https://custom.api.com/api/",
+    });
+    // Trailing slash is removed, /v1 prefix is added
+    expect(client.getStreamUrl("/agents")).toBe(
+      "https://custom.api.com/api/v1/agents",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Fixes URL joining bug where base URLs with paths (e.g., `http://localhost:8080/api`) would lose the path segment when joining with API endpoints
- Normalizes base URLs in all SDKs to ensure correct path joining
- Adds `/v1` prefix to TypeScript paths for consistency with Rust and Python SDKs

## Problem

RFC 3986 URL joining has a pitfall:
- `http://host/api` + `v1/agents` = `http://host/v1/agents` (loses `/api`)
- `http://host/api/` + `v1/agents` = `http://host/api/v1/agents` (correct)

## Changes

| SDK | Fix |
|-----|-----|
| Rust | Add trailing `/` to base URL, use relative paths |
| Python | Add trailing `/` to base URL, use relative paths |
| TypeScript | Remove trailing `/`, add `/v1` prefix |

## Test plan

- [x] All existing tests pass (`just test`)
- [x] New URL normalization tests added for all SDKs
- [x] Examples and cookbook compile
- [x] Linters pass (`just lint`)

https://claude.ai/code/session_01F2QuCfNzweGraeVD4anNsm