### PR TITLE
docs(rust): use cargo add for installation

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -4,11 +4,8 @@ Rust SDK for the Everruns API.
 
 ## Installation
 
-Add to your `Cargo.toml`:
-
-\`\`\`toml
-[dependencies]
-everruns-sdk = "0.1"
+\`\`\`bash
+cargo add everruns-sdk
 \`\`\`
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Updated Rust SDK installation instructions to use `cargo add everruns-sdk`
- Aligns with Python (`pip install`) and TypeScript (`npm install`) SDKs
- `cargo add` is the modern equivalent for adding library dependencies (stable since Rust 1.62)

## Test plan
- [x] Verify README renders correctly
- [x] No code changes, documentation only

https://claude.ai/code/session_016quKNcJKz4xFbvag2YdjGY