### PR TITLE
chore(ci): rename CRATES_IO_TOKEN secret to CARGO_REGISTRY_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cd rust && cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Aligns GitHub secret name with the environment variable `CARGO_REGISTRY_TOKEN` for clarity

## Test plan
- [ ] CI passes
- [ ] Verify secret is configured as `CARGO_REGISTRY_TOKEN` in repo settings before release

https://claude.ai/code/session_01AxjxUbozw3DMQvyytxAGat