### PR TITLE
feat(ci): use trusted publishing for npm and PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,9 @@ jobs:
 
   publish-python:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -39,12 +42,13 @@ jobs:
 
   publish-typescript:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
-      - run: cd typescript && npm ci && npm run build && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: cd typescript && npm ci && npm run build && npm publish --access public --provenance

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -42,16 +42,23 @@ Configure in GitHub Settings → Secrets → Actions:
 | Secret | Registry | How to obtain |
 |--------|----------|---------------|
 | `CARGO_REGISTRY_TOKEN` | crates.io | https://crates.io/settings/tokens |
-| `NPM_TOKEN` | npm | https://www.npmjs.com/settings/~/tokens |
 
-### PyPI Trusted Publishing
+### Trusted Publishing
 
-Python uses PyPI Trusted Publishing (no secret needed):
+Python and TypeScript use OIDC Trusted Publishing (no secrets needed):
 
+**PyPI:**
 1. Go to https://pypi.org/manage/account/publishing/
 2. Add trusted publisher:
    - Owner: `everruns`
    - Repository: `sdk`
+   - Workflow: `publish.yml`
+
+**npm:**
+1. Go to https://www.npmjs.com/package/@everruns/sdk/access
+2. Configure publishing access → Require two-factor authentication or an automation or publish access token
+3. Link to GitHub Actions:
+   - Repository: `everruns/sdk`
    - Workflow: `publish.yml`
 
 ## Changelog Format


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission for OIDC on Python and TypeScript jobs
- Add `--provenance` flag to npm publish
- Remove `NPM_TOKEN` secret dependency
- Update release-process.md spec

## Test plan
- [ ] CI passes
- [ ] Re-run publish workflow after merge

https://claude.ai/code/session_01AxjxUbozw3DMQvyytxAGat