### PR TITLE
feat(ci): add workflow_dispatch trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to allow manual publish runs

## Test plan
- [ ] CI passes
- [ ] After merge, can trigger via: `gh workflow run publish.yml --repo everruns/sdk`

https://claude.ai/code/session_01AxjxUbozw3DMQvyytxAGat