### PR TITLE
docs: use cargo add for Rust installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ Official client libraries for the [Everruns API](https://everruns.com). Build AI
 ## Installation
 
 **Rust**
-```toml
-[dependencies]
-everruns-sdk = "0.1"
+```bash
+cargo add everruns-sdk
 ```
 
 **Python** (3.10+)


### PR DESCRIPTION
## Summary

- Updates Rust installation instructions to use `cargo add everruns-sdk` instead of manually editing `Cargo.toml`
- Consistent with Python (`pip install`) and TypeScript (`npm install`) instructions

## Test Plan

- [x] Docs-only change, no code affected

https://claude.ai/code/session_01QQUuCqJpz2Ztx5jQ29iVT4