### PR TITLE
fix(ci): use env vars in release workflow to prevent script injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,15 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             # Manual trigger: read version from rust/Cargo.toml
             VERSION=$(grep '^version' rust/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           else
             # Push trigger: extract from commit message
-            COMMIT_MSG="${{ github.event.head_commit.message }}"
             VERSION=$(echo "$COMMIT_MSG" | sed -n 's/.*prepare v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
           fi
           if [ -z "$VERSION" ]; then


### PR DESCRIPTION
## Summary

- Fix release workflow failure caused by backticks in commit message body (e.g. `` `just test` ``) being interpreted as bash command substitutions
- Move `github.event.head_commit.message` and `github.event_name` into `env:` block instead of direct `${{ }}` interpolation into bash script

## Test Plan

- [x] Verified failed run 21814065606 — backticks in PR #32 commit body caused `just: command not found`
- [x] Fix passes env vars safely, preventing script injection

## Checklist

- [x] Follows SDK API consistency guidelines
- [ ] Updated relevant specs (if applicable)
- [ ] Added/updated tests
- [x] Updated documentation (if applicable)

https://claude.ai/code/session_011XK7rd7vNxUHj3GXnfwr2N