### PR TITLE
fix(typescript): use repeated keys for exclude param, add expansion tests

### DIFF
--- a/python/tests/test_sse.py
+++ b/python/tests/test_sse.py
@@ -217,3 +217,65 @@ class TestEventStreamState:
 
         stream._update_backoff()
         assert stream._current_backoff_ms == 4000
+
+
+class TestArgumentExpansion:
+    """Tests for SSE query parameter argument expansion.
+
+    The server expects array parameters (like `exclude`) to be sent as
+    repeated query keys: ?exclude=a&exclude=b
+    Not as comma-separated: ?exclude=a,b
+    See: everruns/everruns#575
+    """
+
+    def test_exclude_expands_as_repeated_keys(self):
+        """Exclude values must be repeated keys, not comma-separated."""
+        opts = StreamOptions(exclude=["output.message.delta", "reason.thinking.delta"])
+        stream = EventStream(MockClient(), "session_123", opts)
+        url = stream._build_url()
+        assert "exclude=output.message.delta&exclude=reason.thinking.delta" in url
+        assert "," not in url
+
+    def test_single_exclude_value(self):
+        """Single exclude value produces a single key."""
+        opts = StreamOptions(exclude=["output.message.delta"])
+        stream = EventStream(MockClient(), "session_123", opts)
+        url = stream._build_url()
+        assert url.endswith("?exclude=output.message.delta")
+
+    def test_combined_since_id_and_exclude_expansion(self):
+        """Combined since_id and multiple exclude use repeated keys."""
+        opts = StreamOptions(
+            since_id="evt_001",
+            exclude=["output.message.delta", "reason.thinking.delta"],
+        )
+        stream = EventStream(MockClient(), "session_123", opts)
+        url = stream._build_url()
+        assert "since_id=evt_001" in url
+        assert "exclude=output.message.delta" in url
+        assert "exclude=reason.thinking.delta" in url
+        # Verify ordering: since_id first, then exclude params
+        since_idx = url.index("since_id=")
+        exclude_idx = url.index("exclude=")
+        assert since_idx < exclude_idx
+
+    def test_empty_exclude_no_query_params(self):
+        """Empty exclude array produces no exclude query params."""
+        opts = StreamOptions(exclude=[])
+        stream = EventStream(MockClient(), "session_123", opts)
+        url = stream._build_url()
+        assert "exclude" not in url
+        assert url.endswith("/sse")
+
+    def test_exclude_with_three_values(self):
+        """Three exclude values produce three repeated keys."""
+        opts = StreamOptions(
+            exclude=[
+                "output.message.delta",
+                "reason.thinking.delta",
+                "tool.started",
+            ]
+        )
+        stream = EventStream(MockClient(), "session_123", opts)
+        url = stream._build_url()
+        assert url.count("exclude=") == 3

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -451,3 +451,114 @@ impl std::fmt::Debug for Everruns {
             .finish()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_client() -> Everruns {
+        Everruns::with_base_url("test_key", "https://api.example.com").unwrap()
+    }
+
+    #[test]
+    fn test_sse_url_no_params() {
+        let client = test_client();
+        let url = client.sse_url("session_123", None, &[]);
+        assert_eq!(
+            url.as_str(),
+            "https://api.example.com/v1/sessions/session_123/sse"
+        );
+    }
+
+    #[test]
+    fn test_sse_url_with_since_id() {
+        let client = test_client();
+        let url = client.sse_url("session_123", Some("evt_001"), &[]);
+        assert_eq!(
+            url.as_str(),
+            "https://api.example.com/v1/sessions/session_123/sse?since_id=evt_001"
+        );
+    }
+
+    #[test]
+    fn test_sse_url_exclude_expands_as_repeated_keys() {
+        let client = test_client();
+        let url = client.sse_url(
+            "session_123",
+            None,
+            &["output.message.delta", "reason.thinking.delta"],
+        );
+        let url_str = url.as_str();
+        // Must use repeated keys: ?exclude=a&exclude=b
+        // Not comma-separated: ?exclude=a,b
+        assert!(
+            url_str.contains("exclude=output.message.delta"),
+            "URL missing first exclude: {}",
+            url_str
+        );
+        assert!(
+            url_str.contains("exclude=reason.thinking.delta"),
+            "URL missing second exclude: {}",
+            url_str
+        );
+        assert!(
+            !url_str.contains(','),
+            "URL must not use comma-separated excludes: {}",
+            url_str
+        );
+        assert_eq!(
+            url_str,
+            "https://api.example.com/v1/sessions/session_123/sse?exclude=output.message.delta&exclude=reason.thinking.delta"
+        );
+    }
+
+    #[test]
+    fn test_sse_url_single_exclude() {
+        let client = test_client();
+        let url = client.sse_url("session_123", None, &["output.message.delta"]);
+        assert_eq!(
+            url.as_str(),
+            "https://api.example.com/v1/sessions/session_123/sse?exclude=output.message.delta"
+        );
+    }
+
+    #[test]
+    fn test_sse_url_combined_since_id_and_exclude() {
+        let client = test_client();
+        let url = client.sse_url(
+            "session_123",
+            Some("evt_001"),
+            &["output.message.delta", "reason.thinking.delta"],
+        );
+        assert_eq!(
+            url.as_str(),
+            "https://api.example.com/v1/sessions/session_123/sse?since_id=evt_001&exclude=output.message.delta&exclude=reason.thinking.delta"
+        );
+    }
+
+    #[test]
+    fn test_sse_url_three_exclude_values() {
+        let client = test_client();
+        let url = client.sse_url(
+            "session_123",
+            None,
+            &[
+                "output.message.delta",
+                "reason.thinking.delta",
+                "tool.started",
+            ],
+        );
+        let url_str = url.as_str();
+        assert_eq!(url_str.matches("exclude=").count(), 3);
+    }
+
+    #[test]
+    fn test_sse_url_since_id_special_chars_encoded() {
+        let client = test_client();
+        let url = client.sse_url("session_123", Some("evt&id=1"), &[]);
+        let url_str = url.as_str();
+        // URL should encode special characters
+        assert!(!url_str.contains("evt&id=1"));
+        assert!(url_str.contains("since_id=evt%26id%3D1"));
+    }
+}

--- a/specs/sse-streaming.md
+++ b/specs/sse-streaming.md
@@ -17,6 +17,18 @@ Cache-Control: no-cache
 | `since_id` | string | Resume from event ID (UUIDv7, monotonically increasing) |
 | `exclude` | string[] | Array of event types to filter out |
 
+### Array Parameter Expansion
+
+Array parameters like `exclude` MUST be sent as **repeated query keys** (one key per value), not as comma-separated values or bracket syntax. This matches the `style: form, explode: true` convention in the OpenAPI spec.
+
+```
+Correct:   ?exclude=output.message.delta&exclude=reason.thinking.delta
+Wrong:     ?exclude=output.message.delta,reason.thinking.delta
+Wrong:     ?exclude[]=output.message.delta&exclude[]=reason.thinking.delta
+```
+
+Reference: [everruns/everruns#575](https://github.com/everruns/everruns/pull/575) — the server uses `serde_html_form` which only supports the repeated-key format for deserializing arrays.
+
 ## Event Format
 
 ```
@@ -236,7 +248,7 @@ const opts = { exclude: ["output.message.delta", "reason.thinking.delta"] };
 
 ## URL Building
 
-SDKs must build SSE URLs correctly:
+SDKs must build SSE URLs correctly, using repeated keys for array parameters:
 
 ```
 Base:   /v1/sessions/{session_id}/sse
@@ -245,7 +257,7 @@ With exclude:  /v1/sessions/{session_id}/sse?exclude=output.message.delta
 Combined:      /v1/sessions/{session_id}/sse?since_id={id}&exclude=type1&exclude=type2
 ```
 
-Note: URL-encode special characters in `since_id`.
+Note: URL-encode special characters in `since_id`. Each `exclude` value MUST be a separate query key (see [Array Parameter Expansion](#array-parameter-expansion)).
 
 ## Event ID Handling
 
@@ -277,8 +289,9 @@ SDKs MUST test:
 2. **DisconnectingData parsing** - Valid JSON, missing fields, edge cases
 3. **Backoff calculations** - Sequence, max cap, reset
 4. **URL building** - Basic, with params, encoding
-5. **Retry logic** - Graceful vs unexpected, max retries
-6. **State management** - last_event_id, retry_count, stop()
+5. **Argument expansion** - `exclude` uses repeated keys (not comma-separated), combined params, empty arrays
+6. **Retry logic** - Graceful vs unexpected, max retries
+7. **State management** - last_event_id, retry_count, stop()
 
 ## Implementation Checklist
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -330,7 +330,11 @@ class EventsClient {
   async list(sessionId: string, options?: StreamOptions): Promise<Event[]> {
     const params = new URLSearchParams();
     if (options?.sinceId) params.set("since_id", options.sinceId);
-    if (options?.exclude) params.set("exclude", options.exclude.join(","));
+    if (options?.exclude) {
+      for (const e of options.exclude) {
+        params.append("exclude", e);
+      }
+    }
     const query = params.toString() ? `?${params}` : "";
     const response = await this.client.fetch<{ events: Event[] }>(
       `/sessions/${sessionId}/events${query}`,

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -190,6 +190,37 @@ describe("generateHarnessId", () => {
   });
 });
 
+describe("EventsClient URL building", () => {
+  it("should expand exclude as repeated query keys for events list", () => {
+    // Verify the URLSearchParams approach used by EventsClient.list()
+    // produces repeated keys, not comma-separated values
+    const params = new URLSearchParams();
+    params.set("since_id", "evt_001");
+    for (const e of ["output.message.delta", "reason.thinking.delta"]) {
+      params.append("exclude", e);
+    }
+    const query = params.toString();
+    // Must produce repeated keys: exclude=a&exclude=b
+    expect(query).toBe(
+      "since_id=evt_001&exclude=output.message.delta&exclude=reason.thinking.delta",
+    );
+    expect(query).not.toContain("exclude=output.message.delta%2C");
+  });
+
+  it("should handle single exclude value", () => {
+    const params = new URLSearchParams();
+    for (const e of ["output.message.delta"]) {
+      params.append("exclude", e);
+    }
+    expect(params.toString()).toBe("exclude=output.message.delta");
+  });
+
+  it("should produce empty query for no options", () => {
+    const params = new URLSearchParams();
+    expect(params.toString()).toBe("");
+  });
+});
+
 describe("CreateAgentRequest with client-supplied ID", () => {
   it("should include id in request body", () => {
     const id = generateAgentId();

--- a/typescript/tests/sse.test.ts
+++ b/typescript/tests/sse.test.ts
@@ -81,6 +81,48 @@ describe("EventStream", () => {
       const url = (stream as any).buildUrl();
       expect(url).toContain("since_id=event_123%26special%3Dvalue");
     });
+
+    it("should expand exclude as repeated query keys, not comma-separated", () => {
+      const stream = new EventStream("https://api.example.com/sse", "auth", {
+        exclude: ["output.message.delta", "reason.thinking.delta"],
+      });
+      const url = (stream as any).buildUrl();
+      // Must use repeated keys: ?exclude=a&exclude=b
+      // Not comma-separated: ?exclude=a,b
+      expect(url).toBe(
+        "https://api.example.com/sse?exclude=output.message.delta&exclude=reason.thinking.delta",
+      );
+      expect(url).not.toContain(",");
+    });
+
+    it("should expand single exclude as single key", () => {
+      const stream = new EventStream("https://api.example.com/sse", "auth", {
+        exclude: ["output.message.delta"],
+      });
+      const url = (stream as any).buildUrl();
+      expect(url).toBe(
+        "https://api.example.com/sse?exclude=output.message.delta",
+      );
+    });
+
+    it("should combine since_id and multiple exclude as repeated keys", () => {
+      const stream = new EventStream("https://api.example.com/sse", "auth", {
+        sinceId: "evt_001",
+        exclude: ["output.message.delta", "reason.thinking.delta"],
+      });
+      const url = (stream as any).buildUrl();
+      expect(url).toBe(
+        "https://api.example.com/sse?since_id=evt_001&exclude=output.message.delta&exclude=reason.thinking.delta",
+      );
+    });
+
+    it("should handle empty exclude array", () => {
+      const stream = new EventStream("https://api.example.com/sse", "auth", {
+        exclude: [],
+      });
+      const url = (stream as any).buildUrl();
+      expect(url).toBe("https://api.example.com/sse");
+    });
   });
 
   describe("retry logic", () => {


### PR DESCRIPTION
## Summary

- Fix `EventsClient.list()` in TypeScript sending `exclude` as comma-separated (`?exclude=a,b`) instead of repeated query keys (`?exclude=a&exclude=b`), matching server-side fix in everruns/everruns#575
- Add argument expansion test coverage across all SDKs (TypeScript: 7 tests, Python: 5 tests, Rust: 7 tests) verifying `exclude` uses repeated keys
- Update `specs/sse-streaming.md` to document repeated-key requirement for array parameters

## Test Plan

- All new tests verify `exclude` array params expand as `?exclude=a&exclude=b` (not comma-separated)
- `just test` passes for all SDKs (Rust: 51 passed, Python: 30 passed, TypeScript: 50 passed)
- Linting passes for all changed files

- [x] Tests pass locally
- [x] Coverage ≥80%
- [x] Linting passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)

https://claude.ai/code/session_01V9GZPK3XKo7hkzvz9F5zqk