### PR TITLE
test: add read timeout tests and document decision rationale

### DIFF
--- a/python/tests/test_sse.py
+++ b/python/tests/test_sse.py
@@ -3,6 +3,7 @@
 from everruns_sdk.sse import (
     INITIAL_BACKOFF_MS,
     MAX_RETRY_MS,
+    READ_TIMEOUT_SECS,
     DisconnectingData,
     EventStream,
     StreamOptions,
@@ -127,6 +128,34 @@ class TestBackoffLogic:
     def test_max_backoff_value(self):
         """Test max backoff is 30 seconds."""
         assert MAX_RETRY_MS == 30000
+
+
+class TestReadTimeout:
+    """Tests for SSE read timeout configuration."""
+
+    def test_read_timeout_constant(self):
+        """Read timeout must be 60s, consistent across all SDKs."""
+        assert READ_TIMEOUT_SECS == 60
+
+    def test_read_timeout_under_cycle_interval(self):
+        """Read timeout must be well under the server's 300s cycle interval."""
+        assert READ_TIMEOUT_SECS < 300
+        assert READ_TIMEOUT_SECS >= 30  # Tolerate normal idle periods
+
+    def test_http_client_has_read_timeout(self):
+        """HTTP client must be created with read timeout to detect stalled connections."""
+        stream = EventStream(MockClient(), "session_123", StreamOptions())
+        client = stream._get_http_client()
+        assert client.timeout.read == READ_TIMEOUT_SECS
+
+    def test_http_client_has_no_overall_timeout(self):
+        """SSE streams run for hours; overall timeout must not be set."""
+        stream = EventStream(MockClient(), "session_123", StreamOptions())
+        client = stream._get_http_client()
+        # httpx uses None for no timeout on a specific component
+        # but connect/write/pool have explicit values, read has our timeout
+        assert client.timeout.connect == 30.0
+        assert client.timeout.write == 30.0
 
 
 class TestEventStreamState:

--- a/rust/src/sse.rs
+++ b/rust/src/sse.rs
@@ -24,6 +24,9 @@ use tokio::time::{Sleep, sleep};
 const MAX_RETRY_MS: u64 = 30_000;
 /// Initial retry delay for exponential backoff
 const INITIAL_BACKOFF_MS: u64 = 1000;
+/// Read timeout for detecting stalled/half-open SSE connections (seconds).
+/// Must be well under the server's 300s connection cycle interval.
+pub const READ_TIMEOUT_SECS: u64 = 60;
 
 /// Options for SSE streaming
 #[derive(Debug, Clone, Default)]
@@ -142,7 +145,7 @@ impl EventStream {
         // SSE connections and the `disconnecting` event is lost in transit.
         // 60s is well under the 300s cycle interval (SSE_REALTIME_CYCLE_SECS).
         let sse_http_client = reqwest::Client::builder()
-            .read_timeout(Duration::from_secs(60))
+            .read_timeout(Duration::from_secs(READ_TIMEOUT_SECS))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
 

--- a/rust/tests/sse_test.rs
+++ b/rust/tests/sse_test.rs
@@ -1,6 +1,6 @@
 //! Tests for SSE streaming and retry logic
 
-use everruns_sdk::sse::{DisconnectingData, StreamOptions};
+use everruns_sdk::sse::{DisconnectingData, READ_TIMEOUT_SECS, StreamOptions};
 
 #[test]
 fn test_stream_options_default() {
@@ -63,6 +63,20 @@ fn test_disconnecting_data_parse_zero_retry() {
     let data: DisconnectingData = serde_json::from_str(json).unwrap();
     assert_eq!(data.reason, "immediate_reconnect");
     assert_eq!(data.retry_ms, 0);
+}
+
+#[test]
+fn test_read_timeout_under_cycle_interval() {
+    // Server cycles SSE connections every 300s (SSE_REALTIME_CYCLE_SECS).
+    // Read timeout must be well under that to detect stalled connections
+    // before the next cycle, but long enough to avoid false positives
+    // during legitimate idle periods.
+    assert_eq!(READ_TIMEOUT_SECS, 60);
+    assert!(
+        READ_TIMEOUT_SECS < 300,
+        "must be under server cycle interval"
+    );
+    assert!(READ_TIMEOUT_SECS >= 30, "must tolerate normal idle periods");
 }
 
 #[cfg(test)]

--- a/specs/sse-streaming.md
+++ b/specs/sse-streaming.md
@@ -176,6 +176,16 @@ This ensures that a successful reconnection clears any accumulated error backoff
 | MAX_BACKOFF_MS | 30000 | Maximum retry delay |
 | READ_TIMEOUT_SECS | 60 | Detect stalled connections |
 
+#### Why 60s for READ_TIMEOUT
+
+The server cycles SSE connections every 300s (`SSE_REALTIME_CYCLE_SECS`). When the `disconnecting` event is lost in transit (~6% of connections under load), the TCP connection becomes half-open: the client blocks on read forever.
+
+- **Must be < 300s** — detect the stall before the next cycle
+- **Must be > ~30s** — avoid false positives during legitimate idle periods (model thinking, waiting for user input)
+- **60s** — detects stalls within 1 minute; retry logic reconnects transparently with no data loss (via `since_id`)
+
+This is a **detection-only** mitigation. See [Future: Server-Side Heartbeats](#future-server-side-heartbeats) for the proper fix.
+
 ### Exponential Backoff Sequence
 
 ```
@@ -201,14 +211,14 @@ SDKs should create a dedicated SSE HTTP client once (with SSE-appropriate timeou
 SSE streams can run for hours. SDKs MUST:
 
 1. **Disable overall request timeout** - Set to 0/None/infinite
-2. **Use read timeout** - ~2 minutes to detect stalled connections
+2. **Use read timeout** - 60s to detect stalled connections (see [Why 60s](#why-60s-for-read_timeout))
 3. **Handle keep-alive** - Process periodic events to reset timeouts
 
 ```python
 # Python example
 timeout = httpx.Timeout(
     connect=30.0,
-    read=120.0,      # 2 minute read timeout
+    read=READ_TIMEOUT_SECS,  # 60s — detect stalled connections
     write=30.0,
     pool=30.0,
 )
@@ -217,8 +227,7 @@ timeout = httpx.Timeout(
 ```rust
 // Rust example
 let client = reqwest::Client::builder()
-    .timeout(Duration::from_secs(0))     // No overall timeout
-    .read_timeout(Duration::from_secs(120))
+    .read_timeout(Duration::from_secs(READ_TIMEOUT_SECS)) // 60s
     .build()?;
 ```
 
@@ -318,6 +327,7 @@ SDKs MUST test:
 5. **Argument expansion** - `exclude` uses repeated keys (not comma-separated), combined params, empty arrays
 6. **Retry logic** - Graceful vs unexpected, max retries
 7. **State management** - last_event_id, retry_count, stop()
+8. **Read timeout** - Constant value is 60s, under cycle interval, HTTP client configured with it
 
 ### Smoke / Integration Tests
 8. **Graceful disconnect reconnection** - Mock SSE server sends `connected` → event → `disconnecting`, verify stream reconnects, receives events from second connection, and `retry_count` stays 0
@@ -334,7 +344,7 @@ For new language SDKs:
 - [ ] EventStream async iterator
 - [ ] Graceful disconnect handling (debug log)
 - [ ] Exponential backoff (1s-30s)
-- [ ] Read timeout (2 minutes)
+- [ ] Read timeout (60s)
 - [ ] No overall timeout
 - [ ] since_id tracking
 - [ ] Backoff reset on success and on `connected` event
@@ -343,3 +353,15 @@ For new language SDKs:
 - [ ] stop/abort method
 - [ ] URL building with encoding
 - [ ] Unit tests for all above
+
+## Future: Server-Side Heartbeats
+
+The read timeout is a client-side workaround. The proper fix is server-side heartbeat events:
+
+1. **Server sends periodic heartbeats** (e.g., SSE comment `:heartbeat\n\n` every 30s)
+2. **Client resets read timeout on each heartbeat** — no false positives during idle periods
+3. **Missing heartbeats = stalled connection** — client can use a shorter timeout (e.g., 45s) with confidence
+
+This eliminates the ~6% silent-stall problem at the source rather than detecting it after the fact. Tracked in [everruns/everruns#608](https://github.com/everruns/everruns/issues/608).
+
+Until heartbeats ship, the 60s read timeout + automatic retry is the mitigation.

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -26,4 +26,4 @@ export { Everruns, type EverrunsOptions } from "./client.js";
 export { ApiKey } from "./auth.js";
 export * from "./models.js";
 export * from "./errors.js";
-export { EventStream } from "./sse.js";
+export { EventStream, READ_TIMEOUT_MS } from "./sse.js";

--- a/typescript/src/sse.ts
+++ b/typescript/src/sse.ts
@@ -16,8 +16,9 @@ import { ConnectionError } from "./errors.js";
 const MAX_RETRY_MS = 30_000;
 /** Initial retry delay for exponential backoff */
 const INITIAL_BACKOFF_MS = 1000;
-/** Read timeout for detecting stalled connections (60s) */
-const READ_TIMEOUT_MS = 60_000;
+/** Read timeout for detecting stalled/half-open SSE connections (ms).
+ * Must be well under the server's 300s connection cycle interval. */
+export const READ_TIMEOUT_MS = 60_000;
 
 /**
  * Data from a disconnecting event.

--- a/typescript/tests/sse.test.ts
+++ b/typescript/tests/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { EventStream } from "../src/sse.js";
+import { EventStream, READ_TIMEOUT_MS } from "../src/sse.js";
 
 describe("EventStream", () => {
   describe("configuration", () => {
@@ -262,6 +262,17 @@ describe("Graceful disconnect retry behavior", () => {
 
     expect((stream as any).currentBackoffMs).toBe(1000);
     expect((stream as any).retryCount).toBe(0);
+  });
+});
+
+describe("Read timeout", () => {
+  it("should be 60 seconds, consistent across all SDKs", () => {
+    expect(READ_TIMEOUT_MS).toBe(60_000);
+  });
+
+  it("should be under the server's 300s connection cycle interval", () => {
+    expect(READ_TIMEOUT_MS).toBeLessThan(300_000);
+    expect(READ_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #42 — adds the test coverage and spec documentation that was missing from the initial fix.

- **Tests**: Export `READ_TIMEOUT` constant in all 3 SDKs; add tests asserting value is 60s, under the 300s cycle interval, and that HTTP clients are configured with it
- **Spec rationale**: Add "Why 60s" section explaining the tradeoffs (must be < 300s cycle, > ~30s idle tolerance)
- **Future mitigation**: Add "Server-Side Heartbeats" section — the proper fix that eliminates the ~6% stall problem at the source rather than detecting it client-side
- **Fix stale values**: Update spec examples from 120s → 60s, fix checklist

## Test Plan

- [x] Tests pass locally (`just test` — Rust 58, Python 72, TypeScript 58)
- [x] Coverage ≥80%
- [x] Linting passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)

https://claude.ai/code/session_01Rf3qc4SdWbQxuWtWENQMFP