### PR TITLE
feat(rust,python,typescript): sync SDK with everruns/everruns#603

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -397,6 +397,69 @@
         }
       }
     },
+    "/v1/agents/{agent_id}/copy": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "POST /v1/agents/{agent_id}/copy - Copy an agent",
+        "description": "Creates a new agent with the same configuration as the source agent.\nThe new agent's name will be \"{original name} (copy)\".",
+        "operationId": "copy_agent",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "description": "Source agent ID to copy",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Agent copied successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Source agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/agents/{agent_id}/export": {
       "get": {
         "tags": [
@@ -2683,6 +2746,7 @@
           "events"
         ],
         "summary": "GET /v1/sessions/{session_id}/events - List events (JSON)",
+        "description": "Returns events for a session as a JSON array. Supports filtering by event type\nvia `types` (positive: only these types) and `exclude` (negative: remove these types).\nWhen both are provided, `types` narrows first, then `exclude` removes from that set.\nBoth accept only known event types (max 25 per parameter). Unknown types return 400.",
         "operationId": "list_events",
         "parameters": [
           {
@@ -2711,9 +2775,23 @@
             }
           },
           {
+            "name": "types",
+            "in": "query",
+            "description": "Positive type filter: only return events matching these types (can be specified multiple times).\nWhen empty, all types are returned. Example: ?types=turn.started&types=turn.completed",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
             "name": "exclude",
             "in": "query",
-            "description": "Event types to exclude from the response (can be specified multiple times).\nCommon delta events to exclude: output.message.delta, reason.thinking.delta",
+            "description": "Event types to exclude from the response (can be specified multiple times).\nApplied after `types` filter. Common delta events to exclude: output.message.delta, reason.thinking.delta",
             "required": false,
             "schema": {
               "type": "array",
@@ -2737,7 +2815,7 @@
             }
           },
           "400": {
-            "description": "Invalid session ID"
+            "description": "Invalid session ID or invalid event type filter"
           },
           "404": {
             "description": "Session not found"
@@ -3307,13 +3385,85 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/pin": {
+      "put": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "PUT /v1/sessions/{session_id}/pin - Pin session for current user",
+        "operationId": "pin_session",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID (prefixed, e.g., session_...)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Session pinned successfully"
+          },
+          "400": {
+            "description": "Invalid session ID"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "DELETE /v1/sessions/{session_id}/pin - Unpin session for current user",
+        "operationId": "unpin_session",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID (prefixed, e.g., session_...)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Session unpinned successfully"
+          },
+          "400": {
+            "description": "Invalid session ID"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/v1/sessions/{session_id}/sse": {
       "get": {
         "tags": [
           "events"
         ],
         "summary": "GET /v1/sessions/{session_id}/sse - Stream events (SSE notifications)",
-        "description": "Establishes a Server-Sent Events (SSE) connection for real-time event streaming.\n\n## Connection Lifecycle Events\n\n- **connected**: Sent immediately when the stream is established.\n  Data: `{\"status\":\"connected\"}`\n\n- **disconnecting**: Sent before the server closes the connection for graceful cycling.\n  Data: `{\"reason\":\"connection_cycle\",\"retry_ms\":100}`\n  Clients should reconnect immediately using the `since_id` of the last received event.\n\n## Connection Cycling\n\nConnections are automatically cycled every 5 minutes to prevent stale connections\nthrough proxies and load balancers. Before closing, the server sends a `disconnecting`\nevent so clients can reconnect seamlessly without missing events.\n\n## Retry Hints\n\nEach SSE event includes a `retry:` field (in milliseconds) that hints how long\nclients should wait before reconnecting if the connection is lost:\n- During active streaming: 100ms (fast reconnect)\n- During idle periods: increases with backoff up to 500ms\n- After `disconnecting` event: 100ms (immediate reconnect)\n\n## Resuming Streams\n\nUse the `since_id` query parameter to resume from a specific event. The server\nwill only send events with IDs greater than the specified value. Event IDs are\nUUID v7 (monotonically increasing), ensuring reliable ordering.",
+        "description": "Establishes a Server-Sent Events (SSE) connection for real-time event streaming.\n\n## Connection Lifecycle Events\n\n- **connected**: Sent immediately when the stream is established.\n  Data: `{\"status\":\"connected\"}`\n\n- **disconnecting**: Sent before the server closes the connection for graceful cycling.\n  Data: `{\"reason\":\"connection_cycle\",\"retry_ms\":100}`\n  Clients should reconnect immediately using the `since_id` of the last received event.\n\n## Connection Cycling\n\nConnections are automatically cycled every 5 minutes to prevent stale connections\nthrough proxies and load balancers. Before closing, the server sends a `disconnecting`\nevent so clients can reconnect seamlessly without missing events.\n\n## Retry Hints\n\nEach SSE event includes a `retry:` field (in milliseconds) that hints how long\nclients should wait before reconnecting if the connection is lost:\n- During active streaming: 100ms (fast reconnect)\n- During idle periods: increases with backoff up to 500ms\n- After `disconnecting` event: 100ms (immediate reconnect)\n\n## Resuming Streams\n\nUse the `since_id` query parameter to resume from a specific event. The server\nwill only send events with IDs greater than the specified value. Event IDs are\nUUID v7 (monotonically increasing), ensuring reliable ordering.\n\n## Event Type Filtering\n\nUse `types` for positive filtering (only return these types) and `exclude` for\nnegative filtering (remove these types). When both are provided, `types` narrows\nfirst, then `exclude` removes from that set. Both accept only known event types\n(max 25 per parameter). Unknown types return 400.",
         "operationId": "stream_sse",
         "parameters": [
           {
@@ -3342,9 +3492,23 @@
             }
           },
           {
+            "name": "types",
+            "in": "query",
+            "description": "Positive type filter: only return events matching these types (can be specified multiple times).\nWhen empty, all types are returned. Example: ?types=turn.started&types=turn.completed",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
             "name": "exclude",
             "in": "query",
-            "description": "Event types to exclude from the response (can be specified multiple times).\nCommon delta events to exclude: output.message.delta, reason.thinking.delta",
+            "description": "Event types to exclude from the response (can be specified multiple times).\nApplied after `types` filter. Common delta events to exclude: output.message.delta, reason.thinking.delta",
             "required": false,
             "schema": {
               "type": "array",
@@ -4097,6 +4261,13 @@
             "type": "string",
             "description": "Tool description for LLM"
           },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering (e.g., \"Get Current Time\" for `get_current_time`)"
+          },
           "name": {
             "type": "string",
             "description": "Tool name (used by LLM and for registry lookup)"
@@ -4165,6 +4336,13 @@
             "type": "string",
             "description": "Description of what this capability provides"
           },
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+          },
           "icon": {
             "type": [
               "string",
@@ -4179,6 +4357,10 @@
           "is_mcp": {
             "type": "boolean",
             "description": "Whether this is an MCP server capability (for UI badge)"
+          },
+          "is_skill": {
+            "type": "boolean",
+            "description": "Whether this is an Agent Skill capability (for UI badge)"
           },
           "name": {
             "type": "string",
@@ -4216,6 +4398,13 @@
           "description": {
             "type": "string",
             "description": "Tool description for LLM"
+          },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
           },
           "name": {
             "type": "string",
@@ -5703,6 +5892,13 @@
                   "type": "string",
                   "description": "Description of what this capability provides"
                 },
+                "features": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+                },
                 "icon": {
                   "type": [
                     "string",
@@ -5717,6 +5913,10 @@
                 "is_mcp": {
                   "type": "boolean",
                   "description": "Whether this is an MCP server capability (for UI badge)"
+                },
+                "is_skill": {
+                  "type": "boolean",
+                  "description": "Whether this is an Agent Skill capability (for UI badge)"
                 },
                 "name": {
                   "type": "string",
@@ -7642,6 +7842,15 @@
                 "updated_at"
               ],
               "properties": {
+                "active_schedule_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "int32",
+                  "description": "Number of active (enabled) schedules for this session.\nPopulated when the session is fetched for API responses.",
+                  "minimum": 0
+                },
                 "agent_id": {
                   "type": [
                     "string",
@@ -7662,6 +7871,13 @@
                   "format": "date-time",
                   "description": "Timestamp when the session was created."
                 },
+                "features": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Aggregated UI features from all active capabilities (harness + agent + session).\nComputed at read time from the capability registry.\nKnown features: \"file_system\", \"schedules\", \"secrets\", \"key_value\", \"sql_database\"."
+                },
                 "finished_at": {
                   "type": [
                     "string",
@@ -7679,6 +7895,13 @@
                   "type": "string",
                   "description": "Unique identifier for the session (format: session_{32-hex}).",
                   "example": "session_01933b5a00007000800000000000001"
+                },
+                "is_pinned": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Whether this session is pinned by the current user.\nOnly populated when the request has an authenticated user context."
                 },
                 "model_id": {
                   "type": [
@@ -8366,6 +8589,15 @@
           "updated_at"
         ],
         "properties": {
+          "active_schedule_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Number of active (enabled) schedules for this session.\nPopulated when the session is fetched for API responses.",
+            "minimum": 0
+          },
           "agent_id": {
             "type": [
               "string",
@@ -8386,6 +8618,13 @@
             "format": "date-time",
             "description": "Timestamp when the session was created."
           },
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Aggregated UI features from all active capabilities (harness + agent + session).\nComputed at read time from the capability registry.\nKnown features: \"file_system\", \"schedules\", \"secrets\", \"key_value\", \"sql_database\"."
+          },
           "finished_at": {
             "type": [
               "string",
@@ -8403,6 +8642,13 @@
             "type": "string",
             "description": "Unique identifier for the session (format: session_{32-hex}).",
             "example": "session_01933b5a00007000800000000000001"
+          },
+          "is_pinned": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether this session is pinned by the current user.\nOnly populated when the request has an authenticated user context."
           },
           "model_id": {
             "type": [
@@ -9043,6 +9289,13 @@
           "name"
         ],
         "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
           "id": {
             "type": "string"
           },
@@ -9061,6 +9314,13 @@
           "status"
         ],
         "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
           "duration_ms": {
             "type": [
               "integer",
@@ -9168,6 +9428,13 @@
             "type": "string",
             "description": "Tool description"
           },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
           "name": {
             "type": "string",
             "description": "Tool name"
@@ -9210,6 +9477,13 @@
           "tool_call"
         ],
         "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
           "tool_call": {
             "$ref": "#/components/schemas/ToolCall",
             "description": "The tool call being executed"

--- a/python/everruns_sdk/client.py
+++ b/python/everruns_sdk/client.py
@@ -142,6 +142,11 @@ class Everruns:
         resp = await self._client.patch(self._url(path), json=data)
         return await self._handle_response(resp)
 
+    async def _put_empty(self, path: str) -> None:
+        resp = await self._client.put(self._url(path))
+        if not resp.is_success:
+            await self._raise_error(resp)
+
     async def _delete(self, path: str) -> None:
         resp = await self._client.delete(self._url(path))
         if not resp.is_success:
@@ -261,6 +266,11 @@ class AgentsClient:
         resp = await self._client._post("/agents", req.model_dump(exclude_none=True))
         return Agent(**resp)
 
+    async def copy(self, agent_id: str) -> Agent:
+        """Copy an agent, creating a new agent with the same configuration."""
+        resp = await self._client._post(f"/agents/{agent_id}/copy", {})
+        return Agent(**resp)
+
     async def delete(self, agent_id: str) -> None:
         """Delete (archive) an agent."""
         await self._client._delete(f"/agents/{agent_id}")
@@ -334,6 +344,14 @@ class SessionsClient:
         """Cancel the current turn in a session."""
         await self._client._post(f"/sessions/{session_id}/cancel", {})
 
+    async def pin(self, session_id: str) -> None:
+        """Pin a session for the current user."""
+        await self._client._put_empty(f"/sessions/{session_id}/pin")
+
+    async def unpin(self, session_id: str) -> None:
+        """Unpin a session for the current user."""
+        await self._client._delete(f"/sessions/{session_id}/pin")
+
 
 class MessagesClient:
     """Client for message operations."""
@@ -392,19 +410,37 @@ class EventsClient:
     def __init__(self, client: Everruns):
         self._client = client
 
-    async def list(self, session_id: str) -> list[Event]:
+    async def list(
+        self,
+        session_id: str,
+        *,
+        types: Optional[list[str]] = None,
+        exclude: Optional[list[str]] = None,
+    ) -> list[Event]:
         """List events in a session."""
-        resp = await self._client._get(f"/sessions/{session_id}/events")
+        path = f"/sessions/{session_id}/events"
+        params = []
+        if types:
+            for t in types:
+                params.append(f"types={t}")
+        if exclude:
+            for e in exclude:
+                params.append(f"exclude={e}")
+        if params:
+            path += "?" + "&".join(params)
+        resp = await self._client._get(path)
         return [Event(**e) for e in resp.get("data", [])]
 
     def stream(
         self,
         session_id: str,
+        *,
+        types: Optional[list[str]] = None,
         exclude: Optional[list[str]] = None,
         since_id: Optional[str] = None,
     ) -> EventStream:
         """Stream events from a session via SSE."""
-        options = StreamOptions(exclude=exclude or [], since_id=since_id)
+        options = StreamOptions(types=types or [], exclude=exclude or [], since_id=since_id)
         return EventStream(self._client, session_id, options)
 
 

--- a/python/everruns_sdk/models.py
+++ b/python/everruns_sdk/models.py
@@ -36,6 +36,9 @@ class CapabilityInfo(BaseModel):
     dependencies: list[str] = Field(default_factory=list)
     icon: Optional[str] = None
     is_mcp: bool = False
+    display_name: Optional[str] = None
+    features: list[str] = Field(default_factory=list)
+    is_skill: bool = False
 
 
 class Agent(BaseModel):
@@ -83,6 +86,9 @@ class Session(BaseModel):
     created_at: str
     updated_at: str
     usage: Optional[TokenUsage] = None
+    active_schedule_count: Optional[int] = None
+    features: list[str] = Field(default_factory=list)
+    is_pinned: Optional[bool] = None
 
 
 class TokenUsage(BaseModel):

--- a/python/everruns_sdk/sse.py
+++ b/python/everruns_sdk/sse.py
@@ -32,14 +32,16 @@ DEFAULT_RETRY_MS = 1000
 MAX_RETRY_MS = 30_000
 # Initial retry delay for exponential backoff
 INITIAL_BACKOFF_MS = 1000
-# Read timeout for detecting stalled connections (60s)
-READ_TIMEOUT_SECS = 60
+# Read timeout for detecting stalled connections.
+# Server sends heartbeat comments every 30s; 45s reliably detects stalls.
+READ_TIMEOUT_SECS = 45
 
 
 @dataclass
 class StreamOptions:
     """Options for SSE streaming."""
 
+    types: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
     since_id: Optional[str] = None
     max_retries: Optional[int] = None
@@ -134,6 +136,9 @@ class EventStream:
         since_id = self._last_event_id or self._options.since_id
         if since_id:
             params.append(f"since_id={since_id}")
+
+        for t in self._options.types:
+            params.append(f"types={t}")
 
         for e in self._options.exclude:
             params.append(f"exclude={e}")

--- a/python/tests/test_sse.py
+++ b/python/tests/test_sse.py
@@ -134,13 +134,13 @@ class TestReadTimeout:
     """Tests for SSE read timeout configuration."""
 
     def test_read_timeout_constant(self):
-        """Read timeout must be 60s, consistent across all SDKs."""
-        assert READ_TIMEOUT_SECS == 60
+        """Read timeout must be 45s, above heartbeat interval (30s)."""
+        assert READ_TIMEOUT_SECS == 45
 
-    def test_read_timeout_under_cycle_interval(self):
-        """Read timeout must be well under the server's 300s cycle interval."""
-        assert READ_TIMEOUT_SECS < 300
-        assert READ_TIMEOUT_SECS >= 30  # Tolerate normal idle periods
+    def test_read_timeout_above_heartbeat_interval(self):
+        """Read timeout must be above heartbeat interval and under cycle interval."""
+        assert READ_TIMEOUT_SECS > 30  # Above heartbeat interval
+        assert READ_TIMEOUT_SECS < 300  # Under server cycle interval
 
     def test_http_client_has_read_timeout(self):
         """HTTP client must be created with read timeout to detect stalled connections."""

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -189,6 +189,23 @@ impl Everruns {
         }
     }
 
+    pub(crate) async fn put_empty(&self, path: &str) -> Result<()> {
+        let resp = self
+            .http
+            .put(self.url(path))
+            .headers(self.headers())
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            Err(Error::from_api_response(status, &body))
+        }
+    }
+
     pub(crate) async fn delete(&self, path: &str) -> Result<()> {
         let resp = self
             .http
@@ -224,11 +241,15 @@ impl Everruns {
         &self,
         session_id: &str,
         since_id: Option<&str>,
+        types: &[&str],
         exclude: &[&str],
     ) -> Url {
         let mut url = self.url(&format!("/sessions/{}/sse", session_id));
         if let Some(id) = since_id {
             url.query_pairs_mut().append_pair("since_id", id);
+        }
+        for t in types {
+            url.query_pairs_mut().append_pair("types", t);
         }
         for e in exclude {
             url.query_pairs_mut().append_pair("exclude", e);
@@ -287,6 +308,13 @@ impl<'a> AgentsClient<'a> {
         self.client.post("/agents", &req).await
     }
 
+    /// Copy an agent, creating a new agent with the same configuration
+    pub async fn copy(&self, id: &str) -> Result<Agent> {
+        self.client
+            .post::<Agent, _>(&format!("/agents/{}/copy", id), &())
+            .await
+    }
+
     /// Delete (archive) an agent
     pub async fn delete(&self, id: &str) -> Result<()> {
         self.client.delete(&format!("/agents/{}", id)).await
@@ -343,6 +371,18 @@ impl<'a> SessionsClient<'a> {
             .post::<serde_json::Value, _>(&format!("/sessions/{}/cancel", id), &())
             .await?;
         Ok(())
+    }
+
+    /// Pin a session for the current user
+    pub async fn pin(&self, id: &str) -> Result<()> {
+        self.client
+            .put_empty(&format!("/sessions/{}/pin", id))
+            .await
+    }
+
+    /// Unpin a session for the current user
+    pub async fn unpin(&self, id: &str) -> Result<()> {
+        self.client.delete(&format!("/sessions/{}/pin", id)).await
     }
 }
 
@@ -463,7 +503,7 @@ mod tests {
     #[test]
     fn test_sse_url_no_params() {
         let client = test_client();
-        let url = client.sse_url("session_123", None, &[]);
+        let url = client.sse_url("session_123", None, &[], &[]);
         assert_eq!(
             url.as_str(),
             "https://api.example.com/v1/sessions/session_123/sse"
@@ -473,7 +513,7 @@ mod tests {
     #[test]
     fn test_sse_url_with_since_id() {
         let client = test_client();
-        let url = client.sse_url("session_123", Some("evt_001"), &[]);
+        let url = client.sse_url("session_123", Some("evt_001"), &[], &[]);
         assert_eq!(
             url.as_str(),
             "https://api.example.com/v1/sessions/session_123/sse?since_id=evt_001"
@@ -486,6 +526,7 @@ mod tests {
         let url = client.sse_url(
             "session_123",
             None,
+            &[],
             &["output.message.delta", "reason.thinking.delta"],
         );
         let url_str = url.as_str();
@@ -515,7 +556,7 @@ mod tests {
     #[test]
     fn test_sse_url_single_exclude() {
         let client = test_client();
-        let url = client.sse_url("session_123", None, &["output.message.delta"]);
+        let url = client.sse_url("session_123", None, &[], &["output.message.delta"]);
         assert_eq!(
             url.as_str(),
             "https://api.example.com/v1/sessions/session_123/sse?exclude=output.message.delta"
@@ -528,6 +569,7 @@ mod tests {
         let url = client.sse_url(
             "session_123",
             Some("evt_001"),
+            &[],
             &["output.message.delta", "reason.thinking.delta"],
         );
         assert_eq!(
@@ -542,6 +584,7 @@ mod tests {
         let url = client.sse_url(
             "session_123",
             None,
+            &[],
             &[
                 "output.message.delta",
                 "reason.thinking.delta",
@@ -555,10 +598,40 @@ mod tests {
     #[test]
     fn test_sse_url_since_id_special_chars_encoded() {
         let client = test_client();
-        let url = client.sse_url("session_123", Some("evt&id=1"), &[]);
+        let url = client.sse_url("session_123", Some("evt&id=1"), &[], &[]);
         let url_str = url.as_str();
         // URL should encode special characters
         assert!(!url_str.contains("evt&id=1"));
         assert!(url_str.contains("since_id=evt%26id%3D1"));
+    }
+
+    #[test]
+    fn test_sse_url_with_types() {
+        let client = test_client();
+        let url = client.sse_url(
+            "session_123",
+            None,
+            &["turn.started", "turn.completed"],
+            &[],
+        );
+        assert_eq!(
+            url.as_str(),
+            "https://api.example.com/v1/sessions/session_123/sse?types=turn.started&types=turn.completed"
+        );
+    }
+
+    #[test]
+    fn test_sse_url_with_types_and_exclude() {
+        let client = test_client();
+        let url = client.sse_url(
+            "session_123",
+            Some("evt_001"),
+            &["turn.started"],
+            &["output.message.delta"],
+        );
+        assert_eq!(
+            url.as_str(),
+            "https://api.example.com/v1/sessions/session_123/sse?since_id=evt_001&types=turn.started&exclude=output.message.delta"
+        );
     }
 }

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -48,6 +48,15 @@ pub struct CapabilityInfo {
     pub icon: Option<String>,
     #[serde(default)]
     pub is_mcp: bool,
+    /// Human-readable display name for UI rendering
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// UI feature strings this capability contributes to
+    #[serde(default)]
+    pub features: Vec<String>,
+    /// Whether this is an Agent Skill capability
+    #[serde(default)]
+    pub is_skill: bool,
 }
 
 /// Agent configuration
@@ -180,6 +189,15 @@ pub struct Session {
     pub updated_at: String,
     #[serde(default)]
     pub usage: Option<TokenUsage>,
+    /// Number of active (enabled) schedules for this session
+    #[serde(default)]
+    pub active_schedule_count: Option<i32>,
+    /// Aggregated UI features from all active capabilities
+    #[serde(default)]
+    pub features: Vec<String>,
+    /// Whether this session is pinned by the current user
+    #[serde(default)]
+    pub is_pinned: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/src/sse.rs
+++ b/rust/src/sse.rs
@@ -25,14 +25,17 @@ const MAX_RETRY_MS: u64 = 30_000;
 /// Initial retry delay for exponential backoff
 const INITIAL_BACKOFF_MS: u64 = 1000;
 /// Read timeout for detecting stalled/half-open SSE connections (seconds).
-/// Must be well under the server's 300s connection cycle interval.
-pub const READ_TIMEOUT_SECS: u64 = 60;
+/// The server sends heartbeat comments every 30s. Missing a heartbeat
+/// indicates a stalled connection, so 45s reliably detects them.
+pub const READ_TIMEOUT_SECS: u64 = 45;
 
 /// Options for SSE streaming
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct StreamOptions {
-    /// Event types to exclude from the stream
+    /// Positive type filter: only return events matching these types
+    pub types: Vec<String>,
+    /// Event types to exclude from the stream (applied after `types` filter)
     pub exclude: Vec<String>,
     /// Resume from a specific event ID
     pub since_id: Option<String>,
@@ -49,6 +52,7 @@ impl StreamOptions {
     /// Create options that exclude delta events (for reduced bandwidth)
     pub fn exclude_deltas() -> Self {
         Self {
+            types: vec![],
             exclude: vec![
                 "output.message.delta".to_string(),
                 "reason.thinking.delta".to_string(),
@@ -56,6 +60,12 @@ impl StreamOptions {
             since_id: None,
             max_retries: None,
         }
+    }
+
+    /// Set the positive type filter
+    pub fn with_types(mut self, types: Vec<String>) -> Self {
+        self.types = types;
+        self
     }
 
     /// Set the event types to exclude
@@ -190,6 +200,7 @@ impl EventStream {
             .last_event_id
             .clone()
             .or_else(|| self.options.since_id.clone());
+        let types: Vec<String> = self.options.types.clone();
         let exclude: Vec<String> = self.options.exclude.clone();
         let connected_signal = self.connected_signal.clone();
         let http_client = self.sse_http_client.clone();
@@ -198,8 +209,9 @@ impl EventStream {
             use reqwest_eventsource::{Event as SseEvent, RequestBuilderExt};
             use futures::StreamExt;
 
+            let types_refs: Vec<&str> = types.iter().map(|s| s.as_str()).collect();
             let exclude_refs: Vec<&str> = exclude.iter().map(|s| s.as_str()).collect();
-            let url = client.sse_url(&session_id, since_id.as_deref(), &exclude_refs);
+            let url = client.sse_url(&session_id, since_id.as_deref(), &types_refs, &exclude_refs);
 
             tracing::debug!("Connecting to SSE: {}", url);
 

--- a/rust/tests/sse_test.rs
+++ b/rust/tests/sse_test.rs
@@ -66,17 +66,16 @@ fn test_disconnecting_data_parse_zero_retry() {
 }
 
 #[test]
-fn test_read_timeout_under_cycle_interval() {
-    // Server cycles SSE connections every 300s (SSE_REALTIME_CYCLE_SECS).
-    // Read timeout must be well under that to detect stalled connections
-    // before the next cycle, but long enough to avoid false positives
-    // during legitimate idle periods.
-    assert_eq!(READ_TIMEOUT_SECS, 60);
+fn test_read_timeout_above_heartbeat_interval() {
+    // Server sends heartbeat comments every 30s. Read timeout must be
+    // above that to avoid false positives, but close enough to quickly
+    // detect stalled connections.
+    assert_eq!(READ_TIMEOUT_SECS, 45);
+    assert!(READ_TIMEOUT_SECS > 30, "must be above heartbeat interval");
     assert!(
         READ_TIMEOUT_SECS < 300,
         "must be under server cycle interval"
     );
-    assert!(READ_TIMEOUT_SECS >= 30, "must tolerate normal idle periods");
 }
 
 #[cfg(test)]

--- a/specs/api-surface.md
+++ b/specs/api-surface.md
@@ -14,6 +14,7 @@ SDKs cover agents and sessions functionality. No durable execution endpoints.
 - `DELETE /v1/agents/{id}` - Archive agent
 - `POST /v1/agents/import` - Import agent from Markdown/YAML/JSON/text
 - `GET /v1/agents/{id}/export` - Export agent as Markdown
+- `POST /v1/agents/{id}/copy` - Copy an agent
 
 #### Client-Supplied Agent IDs
 
@@ -29,6 +30,8 @@ When `id` is omitted, the server auto-generates one (plain create).
 - `PATCH /v1/sessions/{id}` - Update session
 - `DELETE /v1/sessions/{id}` - Delete session
 - `POST /v1/sessions/{id}/cancel` - Cancel turn
+- `PUT /v1/sessions/{id}/pin` - Pin session for current user
+- `DELETE /v1/sessions/{id}/pin` - Unpin session for current user
 
 #### Harness ID
 

--- a/specs/sse-streaming.md
+++ b/specs/sse-streaming.md
@@ -15,17 +15,21 @@ Cache-Control: no-cache
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `since_id` | string | Resume from event ID (UUIDv7, monotonically increasing) |
-| `exclude` | string[] | Array of event types to filter out |
+| `types` | string[] | Positive type filter: only return events matching these types |
+| `exclude` | string[] | Event types to exclude (applied after `types` filter) |
 
 ### Array Parameter Expansion
 
-Array parameters like `exclude` MUST be sent as **repeated query keys** (one key per value), not as comma-separated values or bracket syntax. This matches the `style: form, explode: true` convention in the OpenAPI spec.
+Array parameters like `types` and `exclude` MUST be sent as **repeated query keys** (one key per value), not as comma-separated values or bracket syntax. This matches the `style: form, explode: true` convention in the OpenAPI spec.
 
 ```
+Correct:   ?types=turn.started&types=turn.completed
 Correct:   ?exclude=output.message.delta&exclude=reason.thinking.delta
 Wrong:     ?exclude=output.message.delta,reason.thinking.delta
 Wrong:     ?exclude[]=output.message.delta&exclude[]=reason.thinking.delta
 ```
+
+When both `types` and `exclude` are provided, `types` narrows first (positive filter), then `exclude` removes from that set (negative filter). Both accept only known event types (max 25 per parameter). Unknown types return 400.
 
 Reference: [everruns/everruns#575](https://github.com/everruns/everruns/pull/575) — the server uses `serde_html_form` which only supports the repeated-key format for deserializing arrays.
 
@@ -174,17 +178,15 @@ This ensures that a successful reconnection clears any accumulated error backoff
 |----------|-------|-------------|
 | INITIAL_BACKOFF_MS | 1000 | Initial retry delay |
 | MAX_BACKOFF_MS | 30000 | Maximum retry delay |
-| READ_TIMEOUT_SECS | 60 | Detect stalled connections |
+| READ_TIMEOUT_SECS | 45 | Detect stalled connections |
 
-#### Why 60s for READ_TIMEOUT
+#### Why 45s for READ_TIMEOUT
 
-The server cycles SSE connections every 300s (`SSE_REALTIME_CYCLE_SECS`). When the `disconnecting` event is lost in transit (~6% of connections under load), the TCP connection becomes half-open: the client blocks on read forever.
+The server sends heartbeat comments (`: heartbeat\n\n`) every 30s ([everruns/everruns#603](https://github.com/everruns/everruns/issues/603)). These reset the TCP read timer but are ignored by spec-compliant SSE parsers.
 
-- **Must be < 300s** — detect the stall before the next cycle
-- **Must be > ~30s** — avoid false positives during legitimate idle periods (model thinking, waiting for user input)
-- **60s** — detects stalls within 1 minute; retry logic reconnects transparently with no data loss (via `since_id`)
-
-This is a **detection-only** mitigation. See [Future: Server-Side Heartbeats](#future-server-side-heartbeats) for the proper fix.
+- **Must be > 30s** — allow at least one heartbeat interval
+- **45s** — missing a single heartbeat reliably indicates a stalled connection
+- Retry logic reconnects transparently with no data loss (via `since_id`)
 
 ### Exponential Backoff Sequence
 
@@ -211,14 +213,14 @@ SDKs should create a dedicated SSE HTTP client once (with SSE-appropriate timeou
 SSE streams can run for hours. SDKs MUST:
 
 1. **Disable overall request timeout** - Set to 0/None/infinite
-2. **Use read timeout** - 60s to detect stalled connections (see [Why 60s](#why-60s-for-read_timeout))
-3. **Handle keep-alive** - Process periodic events to reset timeouts
+2. **Use read timeout** - 45s to detect stalled connections (see [Why 45s](#why-45s-for-read_timeout))
+3. **Handle heartbeats** - Server sends `: heartbeat\n\n` every 30s; these reset the read timer automatically
 
 ```python
 # Python example
 timeout = httpx.Timeout(
     connect=30.0,
-    read=READ_TIMEOUT_SECS,  # 60s — detect stalled connections
+    read=READ_TIMEOUT_SECS,  # 45s — detect stalled connections
     write=30.0,
     pool=30.0,
 )
@@ -227,7 +229,7 @@ timeout = httpx.Timeout(
 ```rust
 // Rust example
 let client = reqwest::Client::builder()
-    .read_timeout(Duration::from_secs(READ_TIMEOUT_SECS)) // 60s
+    .read_timeout(Duration::from_secs(READ_TIMEOUT_SECS)) // 45s
     .build()?;
 ```
 
@@ -265,7 +267,10 @@ interface StreamOptions {
   // Resume from this event ID
   sinceId?: string;
 
-  // Event types to exclude (reduces bandwidth)
+  // Positive type filter: only return events matching these types
+  types?: string[];
+
+  // Event types to exclude (applied after types filter)
   exclude?: string[];
 
   // Max reconnection attempts (undefined = unlimited)
@@ -285,13 +290,14 @@ const opts = { exclude: ["output.message.delta", "reason.thinking.delta"] };
 SDKs must build SSE URLs correctly, using repeated keys for array parameters:
 
 ```
-Base:   /v1/sessions/{session_id}/sse
-With since_id: /v1/sessions/{session_id}/sse?since_id={event_id}
-With exclude:  /v1/sessions/{session_id}/sse?exclude=output.message.delta
-Combined:      /v1/sessions/{session_id}/sse?since_id={id}&exclude=type1&exclude=type2
+Base:      /v1/sessions/{session_id}/sse
+since_id:  /v1/sessions/{session_id}/sse?since_id={event_id}
+types:     /v1/sessions/{session_id}/sse?types=turn.started&types=turn.completed
+exclude:   /v1/sessions/{session_id}/sse?exclude=output.message.delta
+Combined:  /v1/sessions/{session_id}/sse?since_id={id}&types=turn.started&exclude=output.message.delta
 ```
 
-Note: URL-encode special characters in `since_id`. Each `exclude` value MUST be a separate query key (see [Array Parameter Expansion](#array-parameter-expansion)).
+Note: URL-encode special characters in `since_id`. Each `types` and `exclude` value MUST be a separate query key (see [Array Parameter Expansion](#array-parameter-expansion)).
 
 ## Event ID Handling
 
@@ -324,10 +330,10 @@ SDKs MUST test:
 2. **DisconnectingData parsing** - Valid JSON, missing fields, edge cases
 3. **Backoff calculations** - Sequence, max cap, reset
 4. **URL building** - Basic, with params, encoding
-5. **Argument expansion** - `exclude` uses repeated keys (not comma-separated), combined params, empty arrays
+5. **Argument expansion** - `types` and `exclude` use repeated keys (not comma-separated), combined params, empty arrays
 6. **Retry logic** - Graceful vs unexpected, max retries
 7. **State management** - last_event_id, retry_count, stop()
-8. **Read timeout** - Constant value is 60s, under cycle interval, HTTP client configured with it
+8. **Read timeout** - Constant value is 45s, above heartbeat interval (30s), HTTP client configured with it
 
 ### Smoke / Integration Tests
 8. **Graceful disconnect reconnection** - Mock SSE server sends `connected` → event → `disconnecting`, verify stream reconnects, receives events from second connection, and `retry_count` stays 0
@@ -339,12 +345,12 @@ SDKs MUST test:
 
 For new language SDKs:
 
-- [ ] StreamOptions with sinceId, exclude, maxRetries
+- [ ] StreamOptions with sinceId, types, exclude, maxRetries
 - [ ] DisconnectingData model
 - [ ] EventStream async iterator
 - [ ] Graceful disconnect handling (debug log)
 - [ ] Exponential backoff (1s-30s)
-- [ ] Read timeout (60s)
+- [ ] Read timeout (45s)
 - [ ] No overall timeout
 - [ ] since_id tracking
 - [ ] Backoff reset on success and on `connected` event
@@ -354,14 +360,28 @@ For new language SDKs:
 - [ ] URL building with encoding
 - [ ] Unit tests for all above
 
-## Future: Server-Side Heartbeats
+## Server-Side Heartbeats
 
-The read timeout is a client-side workaround. The proper fix is server-side heartbeat events:
+The server sends periodic SSE comment heartbeats every 30s ([everruns/everruns#603](https://github.com/everruns/everruns/issues/603)):
 
-1. **Server sends periodic heartbeats** (e.g., SSE comment `:heartbeat\n\n` every 30s)
-2. **Client resets read timeout on each heartbeat** — no false positives during idle periods
-3. **Missing heartbeats = stalled connection** — client can use a shorter timeout (e.g., 45s) with confidence
+```
+: heartbeat
 
-This eliminates the ~6% silent-stall problem at the source rather than detecting it after the fact. Tracked in [everruns/everruns#608](https://github.com/everruns/everruns/issues/608).
+```
 
-Until heartbeats ship, the 60s read timeout + automatic retry is the mitigation.
+These are SSE comments (lines starting with `:`) — spec-compliant parsers ignore them automatically. They reset the TCP read timer, allowing reliable detection of stalled connections.
+
+### How Heartbeats Work
+
+1. **Server sends `: heartbeat\n\n` every 30s** across all SSE streams
+2. **Read timeout (45s) > heartbeat interval (30s)** — a missing heartbeat means the connection is stalled
+3. **No SDK code changes needed for parsing** — SSE parsers already ignore comment lines
+4. **Read timeout triggers reconnection** — retry logic reconnects transparently via `since_id`
+
+### Configuration (Server-Side)
+
+| Setting | Default | Env Var |
+|---------|---------|---------|
+| Heartbeat interval | 30s | `SSE_HEARTBEAT_INTERVAL_SECS` |
+
+Heartbeats fire continuously regardless of other server activity and are orthogonal to the 300s connection cycle.

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -195,6 +195,11 @@ class AgentsClient {
     return response.agents;
   }
 
+  /** Copy an agent, creating a new agent with the same configuration. */
+  async copy(agentId: string): Promise<Agent> {
+    return this.client.fetch(`/agents/${agentId}/copy`, { method: "POST" });
+  }
+
   async delete(agentId: string): Promise<void> {
     await this.client.fetch(`/agents/${agentId}`, { method: "DELETE" });
   }
@@ -265,6 +270,20 @@ class SessionsClient {
       method: "POST",
     });
   }
+
+  /** Pin a session for the current user. */
+  async pin(sessionId: string): Promise<void> {
+    await this.client.fetch(`/sessions/${sessionId}/pin`, {
+      method: "PUT",
+    });
+  }
+
+  /** Unpin a session for the current user. */
+  async unpin(sessionId: string): Promise<void> {
+    await this.client.fetch(`/sessions/${sessionId}/pin`, {
+      method: "DELETE",
+    });
+  }
 }
 
 class MessagesClient {
@@ -330,6 +349,11 @@ class EventsClient {
   async list(sessionId: string, options?: StreamOptions): Promise<Event[]> {
     const params = new URLSearchParams();
     if (options?.sinceId) params.set("since_id", options.sinceId);
+    if (options?.types) {
+      for (const t of options.types) {
+        params.append("types", t);
+      }
+    }
     if (options?.exclude) {
       for (const e of options.exclude) {
         params.append("exclude", e);

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -18,6 +18,12 @@ export interface CapabilityInfo {
   dependencies?: string[];
   icon?: string | null;
   isMcp?: boolean;
+  /** Human-readable display name for UI rendering */
+  displayName?: string | null;
+  /** UI feature strings this capability contributes to */
+  features?: string[];
+  /** Whether this is an Agent Skill capability */
+  isSkill?: boolean;
 }
 
 export interface Agent {
@@ -74,6 +80,12 @@ export interface Session {
   capabilities?: AgentCapabilityConfig[];
   createdAt: string;
   updatedAt: string;
+  /** Number of active (enabled) schedules for this session */
+  activeScheduleCount?: number | null;
+  /** Aggregated UI features from all active capabilities */
+  features?: string[];
+  /** Whether this session is pinned by the current user */
+  isPinned?: boolean | null;
 }
 
 export interface CreateSessionRequest {
@@ -187,7 +199,9 @@ export interface Event {
 export interface StreamOptions {
   /** Resume from this event ID */
   sinceId?: string;
-  /** Event types to exclude from the stream */
+  /** Positive type filter: only return events matching these types */
+  types?: string[];
+  /** Event types to exclude from the stream (applied after `types` filter) */
   exclude?: string[];
   /** Maximum number of reconnection attempts (undefined = unlimited) */
   maxRetries?: number;

--- a/typescript/src/sse.ts
+++ b/typescript/src/sse.ts
@@ -17,8 +17,9 @@ const MAX_RETRY_MS = 30_000;
 /** Initial retry delay for exponential backoff */
 const INITIAL_BACKOFF_MS = 1000;
 /** Read timeout for detecting stalled/half-open SSE connections (ms).
- * Must be well under the server's 300s connection cycle interval. */
-export const READ_TIMEOUT_MS = 60_000;
+ * The server sends heartbeat comments every 30s. Missing a heartbeat
+ * indicates a stalled connection, so 45s reliably detects them. */
+export const READ_TIMEOUT_MS = 45_000;
 
 /**
  * Data from a disconnecting event.
@@ -94,6 +95,12 @@ export class EventStream implements AsyncIterable<Event> {
 
     if (this.lastEventId) {
       params.push(`since_id=${encodeURIComponent(this.lastEventId)}`);
+    }
+
+    if (this.options.types) {
+      for (const t of this.options.types) {
+        params.push(`types=${encodeURIComponent(t)}`);
+      }
     }
 
     if (this.options.exclude) {

--- a/typescript/tests/sse.test.ts
+++ b/typescript/tests/sse.test.ts
@@ -266,13 +266,13 @@ describe("Graceful disconnect retry behavior", () => {
 });
 
 describe("Read timeout", () => {
-  it("should be 60 seconds, consistent across all SDKs", () => {
-    expect(READ_TIMEOUT_MS).toBe(60_000);
+  it("should be 45 seconds, above heartbeat interval (30s)", () => {
+    expect(READ_TIMEOUT_MS).toBe(45_000);
   });
 
-  it("should be under the server's 300s connection cycle interval", () => {
+  it("should be above heartbeat interval and under cycle interval", () => {
+    expect(READ_TIMEOUT_MS).toBeGreaterThan(30_000);
     expect(READ_TIMEOUT_MS).toBeLessThan(300_000);
-    expect(READ_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
   });
 });
 


### PR DESCRIPTION
## Summary

- **SSE heartbeats**: Reduce `READ_TIMEOUT` from 60s to 45s — server now sends heartbeat comments every 30s ([everruns/everruns#603](https://github.com/everruns/everruns/issues/603)), enabling reliable stale connection detection
- **New endpoints**: `agents.copy()`, `sessions.pin()`/`sessions.unpin()`, and `types` positive filter on events list/SSE stream
- **New model fields**: `CapabilityInfo.{display_name, features, is_skill}`, `Session.{active_schedule_count, features, is_pinned}`
- **Specs updated**: `sse-streaming.md` (heartbeats documented as implemented, `types` param), `api-surface.md` (new endpoints)

## Test Plan

- [x] Tests pass locally (`just test` — 166 tests across all 3 SDKs)
- [x] Linting passes (`just lint` — cargo fmt/clippy, ruff, oxlint all clean)
- [x] New `types` URL tests added (Rust `test_sse_url_with_types`, `test_sse_url_with_types_and_exclude`)
- [x] Read timeout tests updated to assert 45s

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)

https://claude.ai/code/session_0131GR5ueyAcdaD61FHjDHJH