### PR TITLE
fix(rust): add poll-level idle timeout for half-open SSE connections

### DIFF
--- a/rust/src/sse.rs
+++ b/rust/src/sse.rs
@@ -28,9 +28,14 @@ const INITIAL_BACKOFF_MS: u64 = 1000;
 /// The server sends heartbeat comments every 30s. Missing a heartbeat
 /// indicates a stalled connection, so 45s reliably detects them.
 pub const READ_TIMEOUT_SECS: u64 = 45;
+/// Default idle timeout for detecting half-open connections at the poll level
+/// (seconds). reqwest's read_timeout is ineffective on already-streaming SSE
+/// responses, so EventStream races this timer against inner.poll_next().
+/// 45s = 1.5× the server's 30s heartbeat interval.
+pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 45;
 
 /// Options for SSE streaming
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct StreamOptions {
     /// Positive type filter: only return events matching these types
@@ -41,6 +46,22 @@ pub struct StreamOptions {
     pub since_id: Option<String>,
     /// Maximum number of reconnection attempts (None = unlimited)
     pub max_retries: Option<u32>,
+    /// Idle timeout for detecting half-open connections at the poll level.
+    /// When no events are yielded within this duration, the stream reconnects.
+    /// Default: 45s (1.5× the server's 30s heartbeat interval).
+    pub idle_timeout: Duration,
+}
+
+impl Default for StreamOptions {
+    fn default() -> Self {
+        Self {
+            types: vec![],
+            exclude: vec![],
+            since_id: None,
+            max_retries: None,
+            idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
+        }
+    }
 }
 
 impl StreamOptions {
@@ -52,13 +73,11 @@ impl StreamOptions {
     /// Create options that exclude delta events (for reduced bandwidth)
     pub fn exclude_deltas() -> Self {
         Self {
-            types: vec![],
             exclude: vec![
                 "output.message.delta".to_string(),
                 "reason.thinking.delta".to_string(),
             ],
-            since_id: None,
-            max_retries: None,
+            ..Self::default()
         }
     }
 
@@ -83,6 +102,18 @@ impl StreamOptions {
     /// Set maximum retry attempts
     pub fn with_max_retries(mut self, max_retries: u32) -> Self {
         self.max_retries = Some(max_retries);
+        self
+    }
+
+    /// Set idle timeout for detecting half-open connections.
+    ///
+    /// When no events are yielded within this duration, the stream assumes
+    /// the connection is stale and reconnects. This catches half-open TCP
+    /// connections that reqwest's read_timeout misses on streaming responses.
+    ///
+    /// Default: 45s (1.5× the server's 30s heartbeat interval).
+    pub fn with_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.idle_timeout = timeout;
         self
     }
 }
@@ -145,19 +176,26 @@ pub struct EventStream {
     connected_signal: Arc<AtomicBool>,
     /// Shared reqwest client reused across reconnections for connection pooling
     sse_http_client: reqwest::Client,
+    /// Poll-level idle timer. Fires when no events are yielded within
+    /// `idle_timeout`, triggering reconnection. Catches half-open TCP
+    /// connections that reqwest's read_timeout misses on streaming SSE.
+    idle_deadline: Option<Pin<Box<Sleep>>>,
+    /// Duration before idle_deadline fires
+    idle_timeout: Duration,
 }
 
 impl EventStream {
     pub(crate) fn new(client: Everruns, session_id: String, options: StreamOptions) -> Self {
         // Dedicated SSE client: no overall timeout (streams run for hours),
         // reused across reconnections for connection pool / TCP reuse.
-        // read_timeout detects half-open TCP connections when the server cycles
-        // SSE connections and the `disconnecting` event is lost in transit.
-        // 60s is well under the 300s cycle interval (SSE_REALTIME_CYCLE_SECS).
+        // read_timeout is kept as a secondary safety net, but the primary
+        // stall detection is the poll-level idle_deadline (see poll_next).
         let sse_http_client = reqwest::Client::builder()
             .read_timeout(Duration::from_secs(READ_TIMEOUT_SECS))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
+
+        let idle_timeout = options.idle_timeout;
 
         Self {
             client,
@@ -173,6 +211,8 @@ impl EventStream {
             delay_future: None,
             connected_signal: Arc::new(AtomicBool::new(false)),
             sse_http_client,
+            idle_deadline: None,
+            idle_timeout,
         }
     }
 
@@ -186,6 +226,7 @@ impl EventStream {
         self.should_reconnect = false;
         self.inner = None;
         self.delay_future = None;
+        self.idle_deadline = None;
     }
 
     /// Get the current retry count
@@ -347,14 +388,38 @@ impl Stream for EventStream {
                     return Poll::Ready(None);
                 }
                 self.inner = Some(self.connect());
+                // Start idle timer when a new connection is established
+                self.idle_deadline = Some(Box::pin(sleep(self.idle_timeout)));
+            }
+
+            // Check idle timeout — detects half-open TCP connections where
+            // reqwest's read_timeout is ineffective on streaming SSE.
+            if let Some(ref mut idle) = self.idle_deadline
+                && Pin::new(idle).poll(cx).is_ready()
+            {
+                tracing::warn!(
+                    timeout_secs = self.idle_timeout.as_secs(),
+                    "SSE idle timeout, reconnecting"
+                );
+                self.inner = None;
+                self.idle_deadline = None;
+                if self.should_retry() {
+                    self.retry_count += 1;
+                    let delay = self.get_retry_delay();
+                    self.update_backoff();
+                    self.schedule_reconnect(delay);
+                    continue;
+                }
+                return Poll::Ready(None);
             }
 
             let inner = self.inner.as_mut().unwrap();
             match Pin::new(inner).poll_next(cx) {
                 Poll::Ready(Some(Ok(event))) => {
-                    // Successfully received an event - reset backoff
+                    // Successfully received an event - reset backoff and idle timer
                     self.reset_backoff();
                     self.last_event_id = Some(event.id.clone());
+                    self.idle_deadline = Some(Box::pin(sleep(self.idle_timeout)));
                     return Poll::Ready(Some(Ok(event)));
                 }
                 Poll::Ready(Some(Err(e))) => {
@@ -363,6 +428,7 @@ impl Stream for EventStream {
                         self.server_retry_ms = Some(*retry_ms);
                         self.graceful_disconnect = true;
                         self.inner = None;
+                        self.idle_deadline = None;
 
                         // Graceful disconnects are planned server behavior (connection
                         // cycling), not errors. Don't increment retry_count so they
@@ -380,6 +446,7 @@ impl Stream for EventStream {
                     // Unexpected error - use exponential backoff
                     self.graceful_disconnect = false;
                     self.inner = None;
+                    self.idle_deadline = None;
 
                     if self.should_retry() {
                         self.retry_count += 1;
@@ -399,6 +466,7 @@ impl Stream for EventStream {
                 Poll::Ready(None) => {
                     // Stream ended - always retry to handle read timeout case
                     self.inner = None;
+                    self.idle_deadline = None;
 
                     if self.should_retry() {
                         self.retry_count += 1;
@@ -444,9 +512,20 @@ mod tests {
     fn test_stream_options_builder() {
         let opts = StreamOptions::default()
             .with_since_id("event_123")
-            .with_max_retries(5);
+            .with_max_retries(5)
+            .with_idle_timeout(Duration::from_secs(60));
         assert_eq!(opts.since_id, Some("event_123".to_string()));
         assert_eq!(opts.max_retries, Some(5));
+        assert_eq!(opts.idle_timeout, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_stream_options_default_idle_timeout() {
+        let opts = StreamOptions::default();
+        assert_eq!(
+            opts.idle_timeout,
+            Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS)
+        );
     }
 
     #[test]

--- a/rust/tests/sse_reconnect_test.rs
+++ b/rust/tests/sse_reconnect_test.rs
@@ -5,11 +5,13 @@
 //! - Bug 1: Graceful disconnects don't consume retry budget
 //! - Bug 2: Connected event resets backoff after errors
 //! - Bug 3: HTTP client reused across reconnections (verified via request count)
+//! - Bug 4: Idle timeout triggers reconnection on silent half-open connections
 
 use everruns_sdk::Everruns;
 use futures::StreamExt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 use wiremock::matchers::{method, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -177,4 +179,89 @@ async fn test_connected_event_resets_backoff_after_error() {
 
     // Two connections were made
     assert_eq!(call_count.load(Ordering::SeqCst), 2);
+}
+
+/// Idle timeout must trigger reconnection when a connection goes silent.
+///
+/// Simulates a half-open TCP connection: the first connection sends `connected`
+/// then hangs indefinitely (Poll::Pending). The idle timeout fires, the stream
+/// reconnects, and the second connection delivers an event.
+///
+/// Uses a raw TCP server because wiremock returns bodies immediately (stream
+/// ends with Poll::Ready(None)) and can't simulate a hanging connection.
+#[tokio::test]
+async fn test_idle_timeout_triggers_reconnect_on_silent_connection() {
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connection_count = Arc::new(AtomicUsize::new(0));
+    let count = connection_count.clone();
+
+    // Spawn a mock SSE server
+    tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let n = count.fetch_add(1, Ordering::SeqCst);
+
+            tokio::spawn(async move {
+                // Read the HTTP request (consume it so we can respond)
+                let mut buf = vec![0u8; 4096];
+                let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+
+                let connected = "event: connected\ndata: {}\n\n";
+
+                if n == 0 {
+                    // First connection: send connected, then hang forever
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\n\r\n{}",
+                        connected
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.flush().await;
+                    // Keep connection open — hang forever (simulate half-open)
+                    tokio::time::sleep(Duration::from_secs(300)).await;
+                } else {
+                    // Second connection: send connected + business event
+                    let event_json = format!(
+                        r#"{{"id":"evt_idle_1","type":"session.idled","ts":"2024-01-01T00:00:00Z","session_id":"sess_idle","data":{{}}}}"#
+                    );
+                    let event = format!("event: session.idled\ndata: {}\n\n", event_json);
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\n\r\n{}{}",
+                        connected, event
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.flush().await;
+                }
+            });
+        }
+    });
+
+    let base_url = format!("http://{}", addr);
+    let client = Everruns::with_base_url("test_key", &base_url).unwrap();
+    let opts = everruns_sdk::sse::StreamOptions::default()
+        .with_idle_timeout(Duration::from_secs(2)) // 2s for fast test
+        .with_max_retries(5);
+    let mut stream = client.events().stream_with_options("sess_idle", opts);
+
+    // Should reconnect after 2s idle timeout, get event from 2nd connection
+    let result = tokio::time::timeout(Duration::from_secs(15), stream.next())
+        .await
+        .expect("should not timeout at 15s")
+        .expect("stream should yield an item")
+        .expect("item should be Ok");
+
+    assert_eq!(result.id, "evt_idle_1");
+    assert_eq!(result.event_type, "session.idled");
+
+    // Proves reconnection happened (2+ connections)
+    assert!(
+        connection_count.load(Ordering::SeqCst) >= 2,
+        "Should have made at least 2 connections (got {})",
+        connection_count.load(Ordering::SeqCst)
+    );
+
+    stream.stop();
 }

--- a/rust/tests/sse_test.rs
+++ b/rust/tests/sse_test.rs
@@ -1,6 +1,9 @@
 //! Tests for SSE streaming and retry logic
 
-use everruns_sdk::sse::{DisconnectingData, READ_TIMEOUT_SECS, StreamOptions};
+use everruns_sdk::sse::{
+    DEFAULT_IDLE_TIMEOUT_SECS, DisconnectingData, READ_TIMEOUT_SECS, StreamOptions,
+};
+use std::time::Duration;
 
 #[test]
 fn test_stream_options_default() {
@@ -39,6 +42,37 @@ fn test_stream_options_builder_chain() {
     assert!(opts.exclude.contains(&"output.message.delta".to_string()));
     assert_eq!(opts.since_id, Some("event_abc".to_string()));
     assert_eq!(opts.max_retries, Some(5));
+    // idle_timeout should still be the default
+    assert_eq!(
+        opts.idle_timeout,
+        Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS)
+    );
+}
+
+#[test]
+fn test_stream_options_with_idle_timeout() {
+    let opts = StreamOptions::default().with_idle_timeout(Duration::from_secs(120));
+    assert_eq!(opts.idle_timeout, Duration::from_secs(120));
+}
+
+#[test]
+fn test_stream_options_default_idle_timeout() {
+    let opts = StreamOptions::default();
+    assert_eq!(
+        opts.idle_timeout,
+        Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS)
+    );
+    assert_eq!(opts.idle_timeout, Duration::from_secs(45));
+}
+
+#[test]
+fn test_idle_timeout_constant_above_heartbeat_interval() {
+    // Server heartbeats every 30s. Idle timeout must be above that.
+    assert_eq!(DEFAULT_IDLE_TIMEOUT_SECS, 45);
+    assert!(
+        DEFAULT_IDLE_TIMEOUT_SECS > 30,
+        "idle timeout must be above heartbeat interval"
+    );
 }
 
 #[test]

--- a/specs/sse-streaming.md
+++ b/specs/sse-streaming.md
@@ -114,6 +114,8 @@ current_backoff_ms: int          # Current backoff delay
 retry_count: int                 # Consecutive retry attempts
 should_reconnect: bool           # Whether to continue reconnecting
 graceful_disconnect: bool        # Whether last disconnect was graceful
+idle_deadline: timer | null      # Poll-level idle timer (reset on each yielded event)
+idle_timeout: duration           # Configurable idle timeout duration (default 45s)
 ```
 
 ### Reconnection Strategy
@@ -178,7 +180,8 @@ This ensures that a successful reconnection clears any accumulated error backoff
 |----------|-------|-------------|
 | INITIAL_BACKOFF_MS | 1000 | Initial retry delay |
 | MAX_BACKOFF_MS | 30000 | Maximum retry delay |
-| READ_TIMEOUT_SECS | 45 | Detect stalled connections |
+| READ_TIMEOUT_SECS | 45 | Secondary safety net for stalled connections |
+| DEFAULT_IDLE_TIMEOUT_SECS | 45 | Poll-level idle timeout (primary stall detection) |
 
 #### Why 45s for READ_TIMEOUT
 
@@ -187,6 +190,25 @@ The server sends heartbeat comments (`: heartbeat\n\n`) every 30s ([everruns/eve
 - **Must be > 30s** — allow at least one heartbeat interval
 - **45s** — missing a single heartbeat reliably indicates a stalled connection
 - Retry logic reconnects transparently with no data loss (via `since_id`)
+
+#### Poll-Level Idle Timeout (Primary Stall Detection)
+
+**`reqwest::Client::read_timeout` is ineffective on already-streaming SSE responses.** Despite documentation saying it applies to "time between receiving bytes," it does not fire once `reqwest_eventsource` takes over the response stream. Additionally, SSE heartbeat comments (`: heartbeat\n\n`) are consumed silently by `reqwest_eventsource` and never reach `EventStream::poll_next()`.
+
+**Result:** When a TCP connection goes half-open (server closed, client doesn't know), `stream.next()` returns `Poll::Pending` forever. No timeout, no error, no recovery.
+
+**Fix:** SDKs MUST implement a poll-level idle timeout inside the stream's poll function that races against the inner stream. When no events are yielded within `idle_timeout`, the stream drops the connection and reconnects.
+
+```rust
+// In poll_next():
+// 1. Start idle timer when connection is established
+// 2. Reset idle timer on every yielded event
+// 3. If idle timer fires → drop connection, schedule reconnect
+```
+
+The idle timeout is configurable via `StreamOptions::with_idle_timeout()`. Default: 45s.
+
+**Important:** The idle timer only resets on yielded business events, not on SSE comments (which are invisible to the SDK). Callers with long-idle sessions can increase the timeout.
 
 ### Exponential Backoff Sequence
 
@@ -213,8 +235,9 @@ SDKs should create a dedicated SSE HTTP client once (with SSE-appropriate timeou
 SSE streams can run for hours. SDKs MUST:
 
 1. **Disable overall request timeout** - Set to 0/None/infinite
-2. **Use read timeout** - 45s to detect stalled connections (see [Why 45s](#why-45s-for-read_timeout))
-3. **Handle heartbeats** - Server sends `: heartbeat\n\n` every 30s; these reset the read timer automatically
+2. **Use read timeout** - 45s as secondary safety net (see [Why 45s](#why-45s-for-read_timeout))
+3. **Implement poll-level idle timeout** - 45s default, primary stall detection (see [Poll-Level Idle Timeout](#poll-level-idle-timeout-primary-stall-detection))
+4. **Handle heartbeats** - Server sends `: heartbeat\n\n` every 30s; these reset the read timer but NOT the idle timer (SSE parsers consume comments silently)
 
 ```python
 # Python example
@@ -275,6 +298,9 @@ interface StreamOptions {
 
   // Max reconnection attempts (undefined = unlimited)
   maxRetries?: number;
+
+  // Poll-level idle timeout for detecting half-open connections (default: 45s)
+  idleTimeout?: Duration;
 }
 ```
 
@@ -326,7 +352,7 @@ for event in stream:
 SDKs MUST test:
 
 ### Unit Tests
-1. **StreamOptions** - Default, exclude_deltas, since_id, max_retries
+1. **StreamOptions** - Default, exclude_deltas, since_id, max_retries, idle_timeout
 2. **DisconnectingData parsing** - Valid JSON, missing fields, edge cases
 3. **Backoff calculations** - Sequence, max cap, reset
 4. **URL building** - Basic, with params, encoding
@@ -334,23 +360,26 @@ SDKs MUST test:
 6. **Retry logic** - Graceful vs unexpected, max retries
 7. **State management** - last_event_id, retry_count, stop()
 8. **Read timeout** - Constant value is 45s, above heartbeat interval (30s), HTTP client configured with it
+9. **Idle timeout** - Default is 45s, configurable via `with_idle_timeout()`
 
 ### Smoke / Integration Tests
-8. **Graceful disconnect reconnection** - Mock SSE server sends `connected` → event → `disconnecting`, verify stream reconnects, receives events from second connection, and `retry_count` stays 0
-9. **Backoff reset on reconnection** - After unexpected disconnect (elevated backoff), verify successful reconnection with `connected` event resets backoff to initial values
-10. **Multiple graceful disconnects** - Verify stream survives many sequential graceful disconnects without exhausting `max_retries`
-11. **HTTP client reuse** - Verify the same HTTP client instance is used across reconnections
+10. **Graceful disconnect reconnection** - Mock SSE server sends `connected` → event → `disconnecting`, verify stream reconnects, receives events from second connection, and `retry_count` stays 0
+11. **Backoff reset on reconnection** - After unexpected disconnect (elevated backoff), verify successful reconnection with `connected` event resets backoff to initial values
+12. **Multiple graceful disconnects** - Verify stream survives many sequential graceful disconnects without exhausting `max_retries`
+13. **HTTP client reuse** - Verify the same HTTP client instance is used across reconnections
+14. **Idle timeout reconnection** - Mock SSE server sends `connected` then hangs silent; verify idle timeout fires, stream reconnects, and receives events from second connection
 
 ## Implementation Checklist
 
 For new language SDKs:
 
-- [ ] StreamOptions with sinceId, types, exclude, maxRetries
+- [ ] StreamOptions with sinceId, types, exclude, maxRetries, idleTimeout
 - [ ] DisconnectingData model
 - [ ] EventStream async iterator
 - [ ] Graceful disconnect handling (debug log)
 - [ ] Exponential backoff (1s-30s)
-- [ ] Read timeout (45s)
+- [ ] Read timeout (45s, secondary safety net)
+- [ ] Poll-level idle timeout (45s default, primary stall detection)
 - [ ] No overall timeout
 - [ ] since_id tracking
 - [ ] Backoff reset on success and on `connected` event


### PR DESCRIPTION
## Summary

- Add poll-level idle timeout in `EventStream::poll_next()` that detects half-open TCP connections where `reqwest::Client::read_timeout` is ineffective on already-streaming SSE responses
- New `idle_timeout` field on `StreamOptions` (default 45s, configurable via `with_idle_timeout()`) — when no events are yielded within this duration, the stream drops the stale connection and reconnects transparently
- Update `specs/sse-streaming.md` with idle timeout documentation, state management, and testing requirements

Closes #44

## Test Plan

- [x] Unit tests: `DEFAULT_IDLE_TIMEOUT_SECS` constant, `StreamOptions::with_idle_timeout()`, default value
- [x] Integration test: raw TCP mock server sends `connected` then hangs silent; idle timeout fires after 2s, stream reconnects and receives events from second connection
- [x] All 66 existing tests pass
- [x] Linting passes (`cargo fmt`, `cargo clippy`, `ruff`, `oxlint`)

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)

https://claude.ai/code/session_01CcfHWwQYpGwbHyMf6cCjpS