### PR TITLE
fix(python,typescript): add poll-level idle timeout for half-open SSE connections

### DIFF
--- a/python/everruns_sdk/sse.py
+++ b/python/everruns_sdk/sse.py
@@ -32,9 +32,14 @@ DEFAULT_RETRY_MS = 1000
 MAX_RETRY_MS = 30_000
 # Initial retry delay for exponential backoff
 INITIAL_BACKOFF_MS = 1000
-# Read timeout for detecting stalled connections.
+# Read timeout for detecting stalled connections (secondary safety net).
 # Server sends heartbeat comments every 30s; 45s reliably detects stalls.
 READ_TIMEOUT_SECS = 45
+# Default idle timeout for detecting half-open connections (seconds).
+# httpx's read timeout may be unreliable on streaming SSE responses,
+# so EventStream wraps iteration with asyncio.timeout() as primary
+# stall detection. 45s = 1.5× the server's 30s heartbeat interval.
+DEFAULT_IDLE_TIMEOUT_SECS = 45
 
 
 @dataclass
@@ -45,6 +50,10 @@ class StreamOptions:
     exclude: list[str] = field(default_factory=list)
     since_id: Optional[str] = None
     max_retries: Optional[int] = None
+    idle_timeout: float = DEFAULT_IDLE_TIMEOUT_SECS
+    """Idle timeout in seconds for detecting half-open connections.
+    When no events are yielded within this duration, the stream reconnects.
+    Default: 45s (1.5× the server's 30s heartbeat interval)."""
 
     @classmethod
     def exclude_deltas(cls) -> "StreamOptions":
@@ -179,8 +188,26 @@ class EventStream:
         """Iterate over SSE events with automatic reconnection."""
         while self._should_reconnect:
             try:
-                async for event in self._connect():
-                    yield event
+                async with asyncio.timeout(self._options.idle_timeout) as cm:
+                    async for event in self._connect():
+                        # Reset idle timer on every yielded event
+                        cm.reschedule(asyncio.get_event_loop().time() + self._options.idle_timeout)
+                        yield event
+            except TimeoutError:
+                # Idle timeout fired — no events within idle_timeout.
+                # Likely a half-open TCP connection; reconnect.
+                logger.warning(
+                    "SSE idle timeout (%ss), reconnecting",
+                    self._options.idle_timeout,
+                )
+                self._graceful_disconnect = False
+                if self._should_retry():
+                    self._retry_count += 1
+                    delay = self._get_retry_delay()
+                    self._update_backoff()
+                    await asyncio.sleep(delay)
+                    continue
+                break
             except _GracefulDisconnectError as e:
                 # Server-initiated graceful disconnect (connection cycling).
                 # Not an error — don't increment retry_count so we never

--- a/python/tests/test_sse.py
+++ b/python/tests/test_sse.py
@@ -1,6 +1,7 @@
 """Tests for SSE streaming and retry logic."""
 
 from everruns_sdk.sse import (
+    DEFAULT_IDLE_TIMEOUT_SECS,
     INITIAL_BACKOFF_MS,
     MAX_RETRY_MS,
     READ_TIMEOUT_SECS,
@@ -51,16 +52,29 @@ class TestStreamOptions:
         opts = StreamOptions(max_retries=10)
         assert opts.max_retries == 10
 
+    def test_default_idle_timeout(self):
+        """Test default idle timeout is 45s."""
+        opts = StreamOptions()
+        assert opts.idle_timeout == DEFAULT_IDLE_TIMEOUT_SECS
+        assert opts.idle_timeout == 45
+
+    def test_custom_idle_timeout(self):
+        """Test custom idle timeout."""
+        opts = StreamOptions(idle_timeout=120)
+        assert opts.idle_timeout == 120
+
     def test_full_configuration(self):
         """Test fully configured options."""
         opts = StreamOptions(
             exclude=["output.message.delta"],
             since_id="event_abc",
             max_retries=5,
+            idle_timeout=60,
         )
         assert opts.exclude == ["output.message.delta"]
         assert opts.since_id == "event_abc"
         assert opts.max_retries == 5
+        assert opts.idle_timeout == 60
 
 
 class TestDisconnectingData:
@@ -156,6 +170,23 @@ class TestReadTimeout:
         # but connect/write/pool have explicit values, read has our timeout
         assert client.timeout.connect == 30.0
         assert client.timeout.write == 30.0
+
+
+class TestIdleTimeout:
+    """Tests for SSE idle timeout configuration."""
+
+    def test_idle_timeout_constant(self):
+        """Idle timeout constant must be 45s."""
+        assert DEFAULT_IDLE_TIMEOUT_SECS == 45
+
+    def test_idle_timeout_above_heartbeat_interval(self):
+        """Idle timeout must be above heartbeat interval (30s)."""
+        assert DEFAULT_IDLE_TIMEOUT_SECS > 30
+
+    def test_exclude_deltas_preserves_default_idle_timeout(self):
+        """exclude_deltas() must not change idle_timeout."""
+        opts = StreamOptions.exclude_deltas()
+        assert opts.idle_timeout == DEFAULT_IDLE_TIMEOUT_SECS
 
 
 class TestEventStreamState:

--- a/python/tests/test_sse_reconnect.py
+++ b/python/tests/test_sse_reconnect.py
@@ -5,7 +5,10 @@ to verify:
 - Bug 1: Graceful disconnects don't consume retry budget
 - Bug 2: Connected event resets backoff after errors
 - Bug 3: HTTP client reused across reconnections
+- Bug 4: Idle timeout triggers reconnection on silent half-open connections
 """
+
+import asyncio
 
 import pytest
 
@@ -142,6 +145,49 @@ async def test_http_client_reused_across_reconnections():
 
     # Cleanup
     await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_idle_timeout_triggers_reconnect_on_silent_connection():
+    """Idle timeout must trigger reconnection when _connect() hangs.
+
+    Simulates a half-open TCP connection: the first _connect() yields nothing
+    and hangs forever. The idle timeout fires, the stream reconnects, and the
+    second _connect() delivers an event.
+    """
+    opts = StreamOptions(max_retries=5, idle_timeout=0.5)  # 500ms for fast test
+    stream = EventStream(MockClient(), "sess_1", opts)
+    call_count = 0
+
+    async def mock_connect():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First connection: simulate connected event, then hang forever
+            stream._reset_backoff()
+            # Never yield an event — simulate half-open connection
+            await asyncio.sleep(300)
+            # unreachable, but needed for generator
+            yield make_event("unreachable", "unreachable")  # pragma: no cover
+        else:
+            # Second connection: deliver an event
+            stream._reset_backoff()
+            yield make_event("evt_idle_1", "session.idled")
+
+    stream._connect = mock_connect
+
+    events = []
+    async for event in stream:
+        events.append(event)
+        if len(events) >= 1:
+            stream.stop()
+
+    assert len(events) == 1
+    assert events[0].id == "evt_idle_1"
+    assert events[0].type == "session.idled"
+
+    # Proves reconnection happened
+    assert call_count >= 2, f"Should have reconnected (got {call_count} connections)"
 
 
 @pytest.mark.asyncio

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -26,4 +26,4 @@ export { Everruns, type EverrunsOptions } from "./client.js";
 export { ApiKey } from "./auth.js";
 export * from "./models.js";
 export * from "./errors.js";
-export { EventStream, READ_TIMEOUT_MS } from "./sse.js";
+export { EventStream, READ_TIMEOUT_MS, DEFAULT_IDLE_TIMEOUT_MS } from "./sse.js";

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -205,4 +205,8 @@ export interface StreamOptions {
   exclude?: string[];
   /** Maximum number of reconnection attempts (undefined = unlimited) */
   maxRetries?: number;
+  /** Idle timeout in ms for detecting half-open connections.
+   * When no chunks arrive within this duration, the stream reconnects.
+   * Default: 45000 (1.5× the server's 30s heartbeat interval). */
+  idleTimeoutMs?: number;
 }

--- a/typescript/src/sse.ts
+++ b/typescript/src/sse.ts
@@ -20,6 +20,9 @@ const INITIAL_BACKOFF_MS = 1000;
  * The server sends heartbeat comments every 30s. Missing a heartbeat
  * indicates a stalled connection, so 45s reliably detects them. */
 export const READ_TIMEOUT_MS = 45_000;
+/** Default idle timeout for detecting half-open connections (ms).
+ * Same as READ_TIMEOUT_MS. Configurable via StreamOptions.idleTimeoutMs. */
+export const DEFAULT_IDLE_TIMEOUT_MS = 45_000;
 
 /**
  * Data from a disconnecting event.
@@ -219,10 +222,12 @@ export class EventStream implements AsyncIterable<Event> {
     const url = this.buildUrl();
     console.debug(`Connecting to SSE: ${url}`);
 
+    const idleMs = this.options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+
     // Create abort controller with timeout for stalled connections
     const timeoutId = setTimeout(() => {
       this.abortController?.abort();
-    }, READ_TIMEOUT_MS);
+    }, idleMs);
 
     try {
       const response = await fetch(url, {
@@ -255,9 +260,9 @@ export class EventStream implements AsyncIterable<Event> {
       const resetReadTimeout = () => {
         clearTimeout(readTimeoutId);
         readTimeoutId = setTimeout(() => {
-          console.debug("SSE read timeout, triggering reconnect");
+          console.debug("SSE idle timeout, triggering reconnect");
           reader.cancel();
-        }, READ_TIMEOUT_MS);
+        }, idleMs);
       };
 
       const parser = createParser({

--- a/typescript/tests/sse-reconnect.test.ts
+++ b/typescript/tests/sse-reconnect.test.ts
@@ -5,6 +5,7 @@
  * to verify:
  * - Bug 1: Graceful disconnects don't consume retry budget
  * - Bug 2: Connected event resets backoff after errors
+ * - Bug 4: Idle timeout triggers reconnection on silent half-open connections
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { EventStream } from "../src/sse.js";
@@ -216,4 +217,60 @@ describe("SSE reconnection smoke tests", () => {
     expect(stream.getRetryCount()).toBe(0);
     expect(callCount).toBe(5);
   });
+
+  it("idle timeout triggers reconnect on silent connection", async () => {
+    let callCount = 0;
+
+    globalThis.fetch = vi.fn(async () => {
+      callCount++;
+
+      if (callCount === 1) {
+        // First connection: send connected event then hang (never close).
+        // Creates a ReadableStream that sends connected then stalls.
+        const encoder = new TextEncoder();
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(sseEvent("connected", "{}")),
+              );
+              // Never close or enqueue again — simulates half-open TCP
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+
+      // Second connection: connected + business event
+      return new Response(
+        createSseStream([
+          sseEvent("connected", "{}"),
+          sseEvent(
+            "session.idled",
+            makeEventJson("evt_idle_1", "session.idled"),
+          ),
+        ]),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+    }) as typeof fetch;
+
+    const stream = new EventStream("https://api.example.com/sse", "auth", {
+      maxRetries: 5,
+      idleTimeoutMs: 500, // 500ms for fast test
+    });
+
+    const events: unknown[] = [];
+    for await (const event of stream) {
+      events.push(event);
+      if (events.length >= 1) {
+        stream.abort();
+      }
+    }
+
+    expect(events).toHaveLength(1);
+    expect((events[0] as { id: string }).id).toBe("evt_idle_1");
+
+    // Proves reconnection happened (2+ connections)
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  }, 15_000);
 });

--- a/typescript/tests/sse.test.ts
+++ b/typescript/tests/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { EventStream, READ_TIMEOUT_MS } from "../src/sse.js";
+import { EventStream, READ_TIMEOUT_MS, DEFAULT_IDLE_TIMEOUT_MS } from "../src/sse.js";
 
 describe("EventStream", () => {
   describe("configuration", () => {
@@ -273,6 +273,28 @@ describe("Read timeout", () => {
   it("should be above heartbeat interval and under cycle interval", () => {
     expect(READ_TIMEOUT_MS).toBeGreaterThan(30_000);
     expect(READ_TIMEOUT_MS).toBeLessThan(300_000);
+  });
+});
+
+describe("Idle timeout", () => {
+  it("should default to 45 seconds", () => {
+    expect(DEFAULT_IDLE_TIMEOUT_MS).toBe(45_000);
+  });
+
+  it("should be above heartbeat interval (30s)", () => {
+    expect(DEFAULT_IDLE_TIMEOUT_MS).toBeGreaterThan(30_000);
+  });
+
+  it("should be configurable via StreamOptions.idleTimeoutMs", () => {
+    const stream = new EventStream("https://api.example.com/sse", "auth", {
+      idleTimeoutMs: 120_000,
+    });
+    expect((stream as any).options.idleTimeoutMs).toBe(120_000);
+  });
+
+  it("should use default when idleTimeoutMs is not set", () => {
+    const stream = new EventStream("https://api.example.com/sse", "auth");
+    expect((stream as any).options.idleTimeoutMs).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Port the idle timeout fix from PR #46 (Rust) to Python and TypeScript SDKs
- **Python**: Wrap `_connect()` iteration with `asyncio.timeout()` that resets on each yielded event. When no events arrive within `idle_timeout` (default 45s), the stream reconnects transparently
- **TypeScript**: Make the existing chunk-level `setTimeout` configurable via `StreamOptions.idleTimeoutMs` (default 45s). Previously hardcoded to `READ_TIMEOUT_MS`

Closes #44

## Test Plan

- [x] Python unit tests: `DEFAULT_IDLE_TIMEOUT_SECS` constant, `StreamOptions.idle_timeout` field, default value
- [x] Python integration test: mock `_connect()` that hangs; idle timeout fires after 500ms, stream reconnects and receives events
- [x] TypeScript unit tests: `DEFAULT_IDLE_TIMEOUT_MS` constant, `StreamOptions.idleTimeoutMs` option
- [x] TypeScript integration test: mock `fetch()` returns ReadableStream that hangs after `connected`; idle timeout fires after 500ms, stream reconnects
- [x] All 207 tests pass across all 3 SDKs (66 Rust + 78 Python + 63 TypeScript)
- [x] All linters pass (`cargo fmt/clippy`, `ruff`, `oxlint`)

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable) — done in PR #46
- [x] Added/updated tests
- [x] Updated documentation (if applicable)

https://claude.ai/code/session_01CcfHWwQYpGwbHyMf6cCjpS