### PR TITLE
docs(docs): clarify latest-main workflow for worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 ## Coding-agent guidance
 
+Always make sure you are working on top of latest main from remote. Especially in worktrees: fetch `origin/main`, branch from it, rebase onto it before shipping.
+
 ### Style
 
 Telegraph. Drop filler/grammar. Min tokens.


### PR DESCRIPTION
## Summary

- add an explicit top-level reminder in `AGENTS.md` to stay on the latest remote `main`
- call out the worktree-specific flow: fetch `origin/main`, branch from it, and rebase onto it before shipping

## Test Plan

- [x] `just setup`
- [x] `just lint`
- [x] `just test`
- [x] `just pre-pr`
- [x] Tests pass locally
- [ ] Coverage ≥80%
- [x] Linting passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [ ] Updated relevant specs (if applicable)
- [ ] Added/updated tests
- [x] Updated documentation (if applicable)
