### PR TITLE
fix(ci): add --allow-dirty to cargo publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           echo "Version verified: $TAG_VERSION"
 
       - name: Publish to crates.io
-        run: cd rust && cargo publish
+        run: cd rust && cargo publish --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Fix Rust publish failure caused by Cargo.lock changes during `cargo publish`
- Add `--allow-dirty` flag to allow publishing when Cargo.lock differs

## Test Plan

- [x] Previous publish run failed with `Cargo.lock` dirty error
- [x] `--allow-dirty` is the standard fix for this case