### PR TITLE
refactor: convert ship command to invocable skill

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/ship.md
+++ b/.claude/skills/ship.md
@@ -1,8 +1,14 @@
+---
+name: ship
+description: Ship
+user_invocable: true
+---
+
 # Ship
 
 Run the full ship flow through to **merge on main**. Shipping is not done until the PR is merged.
 
-This command implements the complete "Shipping" definition and Pre-PR Checklist from AGENTS.md. When the user says "ship", "fix and ship", or "ship it", execute ALL 10 phases below — do NOT stop at PR creation. The final deliverable is a merged PR.
+This skill implements the complete "Shipping" definition and Pre-PR Checklist from AGENTS.md. When the user says "ship", "fix and ship", or "ship it", execute ALL 10 phases below — do NOT stop at PR creation. The final deliverable is a merged PR.
 
 ## Arguments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,9 @@ just generate           # Regenerate types from OpenAPI
 - Node 22+, npm
 - `prettier` and `oxlint`
 
-### Commands
+### Skills
 
-`.claude/commands/` contains agent commands.
+`.claude/skills/` contains agent skills (also symlinked at `.agents/skills/`).
 
 - `ship.md` - Full shipping workflow: test, verify artifacts, smoke test, push, PR, merge
 
@@ -100,7 +100,7 @@ just generate           # Regenerate types from OpenAPI
 
 "Ship" means: the change is **merged to main**. Not just "PR created" — merged. The full flow: implement with comprehensive test coverage (positive and negative paths), complete the Pre-PR Checklist, create PR, wait for CI green, squash-merge, confirm merge. Shipping is not done until the PR is merged.
 
-Use the [`/ship`](.claude/commands/ship.md) command to execute the full shipping workflow. When asked to "ship", "fix and ship", or "ship it" — run all 8 phases through to merge. Do not stop at PR creation.
+Use the [`/ship`](.claude/skills/ship.md) skill to execute the full shipping workflow. When asked to "ship", "fix and ship", or "ship it" — run all 10 phases through to merge. Do not stop at PR creation.
 
 ### Pre-PR Checklist
 


### PR DESCRIPTION
## Summary

- Move `.claude/commands/ship.md` to `.claude/skills/ship.md` with `user_invocable: true` frontmatter so `/ship` works as a skill
- Add `.agents/skills` symlink pointing to `.claude/skills/` for cross-tool compatibility
- Update AGENTS.md references from commands to skills

## Test Plan

- [x] Verified symlink resolves correctly
- [x] Verified skill frontmatter is valid

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [ ] Added/updated tests
- [x] Updated documentation (if applicable)