### PR TITLE
chore(release): prepare v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.5] - 2026-03-21
+
+### Highlights
+
+- Session filesystem client methods for file operations within sessions
+- ListResponse pagination fields are now optional across all SDKs
+- Git attribution helpers and pre-push checks for commit identity enforcement
+
+### What's Changed
+
+* fix(rust,python,typescript): make ListResponse pagination fields optional ([#64](https://github.com/everruns/sdk/pull/64)) by @mchalyi
+* feat: add session filesystem client methods ([#62](https://github.com/everruns/sdk/pull/62)) by @mchalyi
+* refactor: convert ship command to invocable skill ([#61](https://github.com/everruns/sdk/pull/61)) by @mchalyi
+* feat(ci): add git attribution helpers and pre-push checks ([#59](https://github.com/everruns/sdk/pull/59)) by @mchalyi
+* fix(ci): add --allow-dirty to cargo publish ([#58](https://github.com/everruns/sdk/pull/58)) by @mchalyi
+
+**Full Changelog**: https://github.com/everruns/sdk/compare/v0.1.4...v0.1.5
+
 ## [0.1.4] - 2026-03-14
 
 ### Highlights

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "everruns-sdk"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python SDK for Everruns API"
 readme = "README.md"
 license = "MIT"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -158,7 +158,7 @@ toml = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-stream",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-sdk"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Rust SDK for Everruns API"
 license = "MIT"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TypeScript SDK for Everruns API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump version to 0.1.5 across all SDK manifests (Rust, Python, TypeScript)
- Update CHANGELOG.md with changes since v0.1.4
- All lints, tests, and publish dry-runs pass

## What's included in v0.1.5

- fix(rust,python,typescript): make ListResponse pagination fields optional (#64)
- feat: add session filesystem client methods (#62)
- refactor: convert ship command to invocable skill (#61)
- feat(ci): add git attribution helpers and pre-push checks (#59)
- fix(ci): add --allow-dirty to cargo publish (#58)

## Test plan

- [x] `just lint` passes
- [x] `just test` passes (all SDKs)
- [x] `just publish-dry-run` passes
- [x] Version matches in all three manifests