### PR TITLE
feat(rust,python,typescript): add session secrets API

### DIFF
--- a/python/everruns_sdk/client.py
+++ b/python/everruns_sdk/client.py
@@ -411,6 +411,18 @@ class SessionsClient:
         """Unpin a session for the current user."""
         await self._client._delete(f"/sessions/{session_id}/pin")
 
+    async def set_secrets(self, session_id: str, secrets: dict[str, str]) -> None:
+        """Batch-set encrypted secrets for a session.
+
+        Args:
+            session_id: Session ID.
+            secrets: Map of secret name to secret value.
+        """
+        await self._client._put(
+            f"/sessions/{session_id}/storage/secrets",
+            {"secrets": secrets},
+        )
+
 
 class MessagesClient:
     """Client for message operations."""

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1020,3 +1020,46 @@ async def test_connections_remove():
         await client.close()
 
     assert route.called
+
+
+# --- Session Secrets Tests ---
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_session_set_secrets():
+    route = respx.put("https://custom.example.com/api/v1/sessions/sess_123/storage/secrets").mock(
+        return_value=httpx.Response(200, json={})
+    )
+
+    client = Everruns(api_key="evr_test_key")
+    try:
+        await client.sessions.set_secrets(
+            "sess_123",
+            {"OPENAI_API_KEY": "sk-abc123", "DB_PASSWORD": "hunter2"},
+        )
+    finally:
+        await client.close()
+
+    assert route.called
+    body = json.loads(route.calls[0].request.content)
+    assert body["secrets"]["OPENAI_API_KEY"] == "sk-abc123"
+    assert body["secrets"]["DB_PASSWORD"] == "hunter2"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_session_set_secrets_empty():
+    route = respx.put("https://custom.example.com/api/v1/sessions/sess_123/storage/secrets").mock(
+        return_value=httpx.Response(200, json={})
+    )
+
+    client = Everruns(api_key="evr_test_key")
+    try:
+        await client.sessions.set_secrets("sess_123", {})
+    finally:
+        await client.close()
+
+    assert route.called
+    body = json.loads(route.calls[0].request.content)
+    assert body["secrets"] == {}

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -436,6 +436,19 @@ impl<'a> SessionsClient<'a> {
     pub async fn unpin(&self, id: &str) -> Result<()> {
         self.client.delete(&format!("/sessions/{}/pin", id)).await
     }
+
+    /// Batch-set encrypted secrets for a session
+    pub async fn set_secrets(
+        &self,
+        id: &str,
+        secrets: &std::collections::HashMap<String, String>,
+    ) -> Result<()> {
+        let req = SetSecretsRequest::new(secrets.clone());
+        self.client
+            .put::<serde_json::Value, _>(&format!("/sessions/{}/storage/secrets", id), &req)
+            .await?;
+        Ok(())
+    }
 }
 
 /// Client for message operations

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -953,6 +953,20 @@ impl SetConnectionRequest {
     }
 }
 
+// --- Session Secrets Models ---
+
+/// Request to batch-set session secrets
+#[derive(Debug, Clone, Serialize)]
+pub struct SetSecretsRequest {
+    pub secrets: std::collections::HashMap<String, String>,
+}
+
+impl SetSecretsRequest {
+    pub fn new(secrets: std::collections::HashMap<String, String>) -> Self {
+        Self { secrets }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/tests/client_test.rs
+++ b/rust/tests/client_test.rs
@@ -624,3 +624,55 @@ async fn test_connections_remove() {
         .await
         .expect("remove connection should succeed");
 }
+
+// --- Session Secrets Tests ---
+
+#[tokio::test]
+async fn test_session_set_secrets() {
+    let server = MockServer::start().await;
+    let client = Everruns::with_base_url("evr_test_key", &server.uri()).expect("client");
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/sessions/sess_123/storage/secrets"))
+        .and(body_json(serde_json::json!({
+            "secrets": {
+                "OPENAI_API_KEY": "sk-abc123",
+                "DB_PASSWORD": "hunter2"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+
+    let mut secrets = std::collections::HashMap::new();
+    secrets.insert("OPENAI_API_KEY".to_string(), "sk-abc123".to_string());
+    secrets.insert("DB_PASSWORD".to_string(), "hunter2".to_string());
+
+    client
+        .sessions()
+        .set_secrets("sess_123", &secrets)
+        .await
+        .expect("set_secrets should succeed");
+}
+
+#[tokio::test]
+async fn test_session_set_secrets_empty() {
+    let server = MockServer::start().await;
+    let client = Everruns::with_base_url("evr_test_key", &server.uri()).expect("client");
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/sessions/sess_123/storage/secrets"))
+        .and(body_json(serde_json::json!({
+            "secrets": {}
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+
+    let secrets = std::collections::HashMap::new();
+    client
+        .sessions()
+        .set_secrets("sess_123", &secrets)
+        .await
+        .expect("set_secrets with empty map should succeed");
+}

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -319,6 +319,17 @@ class SessionsClient {
       method: "DELETE",
     });
   }
+
+  /** Batch-set encrypted secrets for a session. */
+  async setSecrets(
+    sessionId: string,
+    secrets: Record<string, string>,
+  ): Promise<void> {
+    await this.client.fetch(`/sessions/${sessionId}/storage/secrets`, {
+      method: "PUT",
+      body: JSON.stringify({ secrets }),
+    });
+  }
 }
 
 class MessagesClient {

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1016,3 +1016,55 @@ describe("ConnectionsClient", () => {
     );
   });
 });
+
+// --- Session Secrets Tests ---
+
+describe("SessionsClient.setSecrets", () => {
+  it("should batch-set secrets", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Everruns({ apiKey: "evr_test_key" });
+    await client.sessions.setSecrets("sess_123", {
+      OPENAI_API_KEY: "sk-abc123",
+      DB_PASSWORD: "hunter2",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://custom.example.com/api/v1/sessions/sess_123/storage/secrets",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          secrets: {
+            OPENAI_API_KEY: "sk-abc123",
+            DB_PASSWORD: "hunter2",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("should handle empty secrets map", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Everruns({ apiKey: "evr_test_key" });
+    await client.sessions.setSecrets("sess_123", {});
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://custom.example.com/api/v1/sessions/sess_123/storage/secrets",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ secrets: {} }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add native `client.sessions().set_secrets()` method across all three SDKs (Rust, Python, TypeScript)
- Batch-set encrypted secrets via `PUT /v1/sessions/:id/storage/secrets`
- Includes `SetSecretsRequest` model (Rust) and full test coverage in all languages

## Test Plan

- [x] Tests pass locally (`just test`)
- [x] Coverage ≥80%
- [x] Linting passes (`just lint`)

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)

Closes #67