### PR TITLE
chore(release): prepare v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.1.6] - 2026-04-01
+
+### Highlights
+
+- Session secrets API for managing secrets within sessions
+- Connections API for managing external service connections
+- Dependency upgrades across all SDKs
+
+### What's Changed
+
+* feat(rust,python,typescript): add session secrets API ([#69](https://github.com/everruns/sdk/pull/69)) by @mchalyi
+* feat(rust,python,typescript): add connections API ([#68](https://github.com/everruns/sdk/pull/68)) by @mchalyi
+* chore(rust,python,typescript): upgrade dependencies across all SDKs ([#70](https://github.com/everruns/sdk/pull/70)) by @mchalyi
+
+**Full Changelog**: https://github.com/everruns/sdk/compare/v0.1.5...v0.1.6
+
 ## [0.1.5] - 2026-03-21
 
 ### Highlights

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "everruns-sdk"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for Everruns API"
 readme = "README.md"
 license = "MIT"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-sdk"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Rust SDK for Everruns API"
 license = "MIT"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TypeScript SDK for Everruns API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump version to 0.1.6 across all SDKs (Rust, Python, TypeScript)
- Update CHANGELOG.md with v0.1.6 release notes

### Changes since v0.1.5

- Session secrets API for managing secrets within sessions (#69)
- Connections API for managing external service connections (#68)
- Dependency upgrades across all SDKs (#70)

## Test plan

- [ ] CI passes (lint, test, build)
- [ ] Version numbers match across all manifests
- [ ] CHANGELOG.md is accurate
- [ ] `release.yml` triggers on merge and creates GitHub Release
- [ ] `publish.yml` publishes to crates.io, PyPI, and npm