### PR TITLE
feat(rust,python,typescript): add session export JSONL support

### DIFF
--- a/python/everruns_sdk/client.py
+++ b/python/everruns_sdk/client.py
@@ -459,6 +459,14 @@ class SessionsClient:
             {"secrets": secrets},
         )
 
+    async def export(self, session_id: str) -> str:
+        """Export a session's messages as JSONL.
+
+        Args:
+            session_id: Session ID.
+        """
+        return await self._client._get_text(f"/sessions/{session_id}/export")
+
 
 class MessagesClient:
     """Client for message operations."""

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1311,6 +1311,30 @@ async def test_session_resume():
     assert route.called
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_session_export():
+    jsonl = (
+        '{"id":"msg_001","session_id":"sess_123","sequence":1,"role":"user",'
+        '"content":[{"type":"text","text":"hello"}],"created_at":"2024-01-15T10:30:00.000Z"}\n'
+        '{"id":"msg_002","session_id":"sess_123","sequence":2,"role":"agent",'
+        '"content":[{"type":"text","text":"hi"}],"created_at":"2024-01-15T10:30:01.000Z"}\n'
+    )
+    route = respx.get("https://custom.example.com/api/v1/sessions/sess_123/export").mock(
+        return_value=httpx.Response(200, text=jsonl)
+    )
+
+    client = Everruns(api_key="evr_test_key")
+    try:
+        result = await client.sessions.export("sess_123")
+    finally:
+        await client.close()
+
+    assert "msg_001" in result
+    assert "msg_002" in result
+    assert route.called
+
+
 def test_budget_model():
     """Test Budget model deserialization."""
     from everruns_sdk import Budget

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -172,7 +172,7 @@ toml = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.5"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -472,6 +472,13 @@ impl<'a> SessionsClient<'a> {
             .await?;
         Ok(())
     }
+
+    /// Export a session's messages as JSONL
+    pub async fn export(&self, id: &str) -> Result<String> {
+        self.client
+            .get_text(&format!("/sessions/{}/export", id))
+            .await
+    }
 }
 
 /// Client for message operations

--- a/rust/tests/client_test.rs
+++ b/rust/tests/client_test.rs
@@ -1014,3 +1014,26 @@ async fn test_session_resume() {
     assert_eq!(result.resumed_budgets, 2);
     assert_eq!(result.session_id, "sess_123");
 }
+
+#[tokio::test]
+async fn test_session_export() {
+    let server = MockServer::start().await;
+    let client = Everruns::with_base_url("evr_test_key", &server.uri()).expect("client");
+
+    let jsonl = "{\"id\":\"msg_001\",\"session_id\":\"sess_123\",\"sequence\":1,\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}],\"created_at\":\"2024-01-15T10:30:00.000Z\"}\n{\"id\":\"msg_002\",\"session_id\":\"sess_123\",\"sequence\":2,\"role\":\"agent\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}],\"created_at\":\"2024-01-15T10:30:01.000Z\"}\n";
+
+    Mock::given(method("GET"))
+        .and(path("/v1/sessions/sess_123/export"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(jsonl))
+        .mount(&server)
+        .await;
+
+    let result = client
+        .sessions()
+        .export("sess_123")
+        .await
+        .expect("export should succeed");
+
+    assert!(result.contains("msg_001"));
+    assert!(result.contains("msg_002"));
+}

--- a/specs/api-surface.md
+++ b/specs/api-surface.md
@@ -34,6 +34,7 @@ Agent create/update payloads also support optional `initial_files` starter files
 - `POST /v1/sessions/{id}/cancel` - Cancel turn
 - `PUT /v1/sessions/{id}/pin` - Pin session for current user
 - `DELETE /v1/sessions/{id}/pin` - Unpin session for current user
+- `GET /v1/sessions/{id}/export` - Export session messages as JSONL
 
 #### Harness ID
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -356,6 +356,11 @@ class SessionsClient {
       body: JSON.stringify({ secrets }),
     });
   }
+
+  /** Export a session's messages as JSONL. */
+  async export(sessionId: string): Promise<string> {
+    return this.client.fetchText(`/sessions/${sessionId}/export`);
+  }
 }
 
 class MessagesClient {

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1338,4 +1338,26 @@ describe("Session budget shortcuts", () => {
       expect.objectContaining({ method: "POST" }),
     );
   });
+
+  it("should export session as JSONL", async () => {
+    const jsonl =
+      '{"id":"msg_001","session_id":"sess_123","sequence":1,"role":"user","content":[{"type":"text","text":"hello"}],"created_at":"2024-01-15T10:30:00.000Z"}\n' +
+      '{"id":"msg_002","session_id":"sess_123","sequence":2,"role":"agent","content":[{"type":"text","text":"hi"}],"created_at":"2024-01-15T10:30:01.000Z"}\n';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => jsonl,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Everruns({ apiKey: "evr_test_key" });
+    const result = await client.sessions.export("sess_123");
+
+    expect(result).toContain("msg_001");
+    expect(result).toContain("msg_002");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://custom.example.com/api/v1/sessions/sess_123/export",
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Add `sessions.export()` method to Rust, Python, and TypeScript SDKs
- Calls `GET /v1/sessions/{id}/export` returning raw JSONL string
- Follows existing `agents.export()` pattern using `get_text`/`fetchText`

Closes #75

## Test Plan

- Added `test_session_export` to all three SDK test suites
- Mocks verify correct URL construction and response handling

- [x] Tests pass locally
- [x] Coverage ≥80%
- [x] Linting passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)