### PR TITLE
chore(release): prepare v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.1.8] - 2026-04-15
+
+### Highlights
+
+- Session export JSONL support across Rust, Python, and TypeScript SDKs
+- `harness_name`, unique agent names, and upsert-by-name support across all SDKs
+- Refreshed generated schemas, capability listing/import support, and maintenance updates
+
+### What's Changed
+
+* chore: periodic maintenance ([#80](https://github.com/everruns/sdk/pull/80)) by @chaliy
+* feat(rust,python,typescript): unique agent names with upsert-by-name ([#79](https://github.com/everruns/sdk/pull/79)) by @chaliy
+* feat(rust,python,typescript): support harness_name in session creation ([#78](https://github.com/everruns/sdk/pull/78)) by @chaliy
+* feat(rust,python,typescript): add session export JSONL support ([#76](https://github.com/everruns/sdk/pull/76)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/sdk/compare/v0.1.7...v0.1.8
+
 ## [0.1.7] - 2026-04-05
 
 ### Highlights

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "everruns-sdk"
-version = "0.1.7"
+version = "0.1.8"
 description = "Python SDK for Everruns API"
 readme = "README.md"
 license = "MIT"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -172,7 +172,7 @@ toml = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-stream",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-sdk"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Rust SDK for Everruns API"
 license = "MIT"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/sdk",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TypeScript SDK for Everruns API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- bump Rust, Python, and TypeScript SDK package versions to `0.1.8`
- add the `0.1.8` changelog entry for PRs `#80`, `#79`, `#78`, and `#76`
- refresh language lockfiles generated by the release verification steps

## Test Plan

- [x] Tests pass locally (`just pre-pr`)
- [x] Coverage ≥80%
- [x] Linting passes
- [x] `just pre-push`
- [x] `just publish-dry-run`

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)