### PR TITLE
feat: add org context support across SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Set your API key:
 export EVERRUNS_API_KEY=evr_your_key_here
 ```
 
+For API keys with access to multiple organizations, also set:
+```bash
+export EVERRUNS_ORG_ID=org_your_org_id_here
+```
+
 ### Rust
 
 ```rust
@@ -157,21 +162,24 @@ main();
 
 ## Authentication
 
-All SDKs read from `EVERRUNS_API_KEY` environment variable by default, or accept an explicit key:
+All SDKs read from `EVERRUNS_API_KEY` by default. Multi-org API-key users can set `EVERRUNS_ORG_ID` or pass an explicit organization ID:
 
 ```rust
 // Rust
-let client = Everruns::new("evr_...");
+let client = Everruns::builder()
+    .api_key("evr_...")
+    .org_id("org_...")
+    .build()?;
 ```
 
 ```python
 # Python
-client = Everruns(api_key="evr_...")
+client = Everruns(api_key="evr_...", org_id="org_...")
 ```
 
 ```typescript
 // TypeScript
-const client = new Everruns({ apiKey: "evr_..." });
+const client = new Everruns({ apiKey: "evr_...", orgId: "org_..." });
 ```
 
 ## Error Handling

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,6 +27,8 @@ npm install @everruns/sdk
 
 ```bash
 export EVERRUNS_API_KEY=evr_...
+# Optional for API keys with access to multiple organizations:
+export EVERRUNS_ORG_ID=org_...
 ```
 
 ### 2. Create Client
@@ -34,7 +36,7 @@ export EVERRUNS_API_KEY=evr_...
 ```python
 from everruns_sdk import Everruns
 
-client = Everruns(org="my-org")
+client = Everruns()
 ```
 
 ### 3. Create an Agent

--- a/python/README.md
+++ b/python/README.md
@@ -15,7 +15,7 @@ import asyncio
 from everruns_sdk import Everruns
 
 async def main():
-    # Uses EVERRUNS_API_KEY environment variable
+    # Uses EVERRUNS_API_KEY and optional EVERRUNS_ORG_ID environment variables
     client = Everruns()
     
     # Create an agent
@@ -67,6 +67,18 @@ session = await client.sessions.create(
 ```
 
 Runnable example: [`examples/initial_files.py`](examples/initial_files.py)
+
+## Authentication
+
+The SDK uses API key authentication. Set `EVERRUNS_API_KEY` or pass the key explicitly. For API keys with access to multiple organizations, set `EVERRUNS_ORG_ID` or pass `org_id` explicitly:
+
+```python
+# From environment
+client = Everruns()
+
+# Explicit key and organization
+client = Everruns(api_key="evr_...", org_id="org_...")
+```
 
 ## License
 

--- a/python/everruns_sdk/__init__.py
+++ b/python/everruns_sdk/__init__.py
@@ -16,6 +16,7 @@ from everruns_sdk.errors import (
     EverrunsError,
     NotFoundError,
     RateLimitError,
+    ValidationError,
 )
 from everruns_sdk.models import (
     Agent,
@@ -61,6 +62,7 @@ __all__ = [
     "AuthenticationError",
     "NotFoundError",
     "RateLimitError",
+    "ValidationError",
     "Agent",
     "AgentCapabilityConfig",
     "Budget",

--- a/python/everruns_sdk/client.py
+++ b/python/everruns_sdk/client.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 import httpx
 
 from everruns_sdk.auth import ApiKey
-from everruns_sdk.errors import ApiError
+from everruns_sdk.errors import ApiError, ValidationError
 from everruns_sdk.models import (
     Agent,
     AgentCapabilityConfig,
@@ -66,12 +66,23 @@ def _with_query(path: str, params: dict[str, Any]) -> str:
     return f"{path}?{query}"
 
 
+def _validate_org_id(org_id: Optional[str]) -> Optional[str]:
+    if org_id is None:
+        return None
+    if not org_id:
+        raise ValidationError("org_id cannot be empty")
+    if any(char in org_id for char in ("\r", "\n", "\0")):
+        raise ValidationError("org_id contains invalid header characters")
+    return org_id
+
+
 class Everruns:
     """Main client for interacting with the Everruns API.
 
     Args:
         api_key: API key (optional, defaults to EVERRUNS_API_KEY env var)
         base_url: Base URL for the API (optional)
+        org_id: Organization ID (optional, defaults to EVERRUNS_ORG_ID env var)
 
     Example:
         >>> client = Everruns()
@@ -82,6 +93,7 @@ class Everruns:
         self,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
+        org_id: Optional[str] = None,
     ):
         """Initialize Everruns client.
 
@@ -89,6 +101,8 @@ class Everruns:
             api_key: API key (falls back to EVERRUNS_API_KEY env var)
             base_url: API base URL (falls back to EVERRUNS_API_URL env var,
                       then DEFAULT_BASE_URL)
+            org_id: Organization ID sent as X-Org-Id (falls back to
+                    EVERRUNS_ORG_ID env var)
         """
         if api_key is None:
             api_key = os.environ.get("EVERRUNS_API_KEY")
@@ -99,8 +113,11 @@ class Everruns:
                 )
         if base_url is None:
             base_url = os.environ.get("EVERRUNS_API_URL", DEFAULT_BASE_URL)
+        if org_id is None:
+            org_id = os.environ.get("EVERRUNS_ORG_ID") or None
 
         self._api_key = ApiKey(api_key)
+        self._org_id = _validate_org_id(org_id)
         # Ensure base URL has trailing slash for correct URL joining.
         # httpx follows RFC 3986: without trailing slash, relative paths
         # replace the last path segment instead of appending.
@@ -109,10 +126,7 @@ class Everruns:
         self._base_url = base_url.rstrip("/") + "/"
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
-            headers={
-                "Authorization": self._api_key.value,
-                "Content-Type": "application/json",
-            },
+            headers=self._auth_headers(),
             timeout=30.0,
         )
 
@@ -162,6 +176,14 @@ class Everruns:
         path_without_slash = path.lstrip("/")
         return f"v1/{path_without_slash}"
 
+    def _auth_headers(self, *, content_type: Optional[str] = "application/json") -> dict[str, str]:
+        headers = {"Authorization": self._api_key.value}
+        if content_type is not None:
+            headers["Content-Type"] = content_type
+        if self._org_id is not None:
+            headers["X-Org-Id"] = self._org_id
+        return headers
+
     async def _get(self, path: str) -> Any:
         resp = await self._client.get(self._url(path))
         return await self._handle_response(resp)
@@ -181,7 +203,7 @@ class Everruns:
         resp = await self._client.post(
             self._url(path),
             content=content,
-            headers={"Content-Type": "text/plain"},
+            headers=self._auth_headers(content_type="text/plain"),
         )
         return await self._handle_response(resp)
 

--- a/python/everruns_sdk/errors.py
+++ b/python/everruns_sdk/errors.py
@@ -62,3 +62,9 @@ class RateLimitError(ApiError):
     """Rate limit exceeded (429)."""
 
     pass
+
+
+class ValidationError(EverrunsError):
+    """Client-side validation failed."""
+
+    pass

--- a/python/everruns_sdk/sse.py
+++ b/python/everruns_sdk/sse.py
@@ -157,6 +157,13 @@ class EventStream:
 
         return url
 
+    def _headers(self) -> dict[str, str]:
+        return {
+            **self._client._auth_headers(content_type=None),
+            "Accept": "text/event-stream",
+            "Cache-Control": "no-cache",
+        }
+
     def _get_retry_delay(self) -> float:
         """Get the retry delay in seconds."""
         if self._graceful_disconnect:
@@ -262,11 +269,7 @@ class EventStream:
             http,
             "GET",
             url,
-            headers={
-                "Authorization": self._client._api_key.value,
-                "Accept": "text/event-stream",
-                "Cache-Control": "no-cache",
-            },
+            headers=self._headers(),
         ) as event_source:
             async for sse in event_source.aiter_sse():
                 # Handle special lifecycle events

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -13,6 +13,7 @@ from everruns_sdk import (
     ContentPart,
     Everruns,
     InitialFile,
+    ValidationError,
 )
 
 
@@ -54,6 +55,12 @@ def test_client_creation():
     assert client._api_key.value == "evr_test_key"
 
 
+def test_client_creation_with_org_id():
+    """Test client creation with explicit org ID."""
+    client = Everruns(api_key="evr_test_key", org_id="org_123")
+    assert client._org_id == "org_123"
+
+
 def test_client_from_env():
     """Test client creation from environment variable."""
     os.environ["EVERRUNS_API_KEY"] = "evr_from_env"
@@ -62,6 +69,32 @@ def test_client_from_env():
         assert client._api_key.value == "evr_from_env"
     finally:
         del os.environ["EVERRUNS_API_KEY"]
+
+
+def test_client_from_env_reads_org_id(monkeypatch):
+    """Test client creation reads organization ID from environment."""
+    monkeypatch.setenv("EVERRUNS_API_KEY", "evr_from_env")
+    monkeypatch.setenv("EVERRUNS_ORG_ID", "org_from_env")
+
+    client = Everruns()
+
+    assert client._api_key.value == "evr_from_env"
+    assert client._org_id == "org_from_env"
+
+
+def test_client_explicit_org_id_precedes_env(monkeypatch):
+    """Test explicit org ID wins over environment."""
+    monkeypatch.setenv("EVERRUNS_ORG_ID", "org_from_env")
+
+    client = Everruns(api_key="evr_test_key", org_id="org_explicit")
+
+    assert client._org_id == "org_explicit"
+
+
+def test_client_rejects_invalid_org_id():
+    """Test invalid org ID header values fail at client creation."""
+    with pytest.raises(ValidationError):
+        Everruns(api_key="evr_test_key", org_id="bad\norg")
 
 
 def test_client_missing_api_key():
@@ -92,6 +125,23 @@ def test_url_path_construction():
     # The _url method should produce relative paths without leading slash
     assert client._url("/agents") == "v1/agents"
     assert client._url("/sessions/123") == "v1/sessions/123"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_client_sends_org_id_header():
+    route = respx.get("https://custom.example.com/api/v1/agents").mock(
+        return_value=httpx.Response(200, json={"data": [], "total": 0, "offset": 0, "limit": 0})
+    )
+
+    client = Everruns(api_key="evr_test_key", org_id="org_123")
+    try:
+        await client.agents.list()
+    finally:
+        await client.close()
+
+    assert route.called
+    assert route.calls[0].request.headers["X-Org-Id"] == "org_123"
 
 
 def test_capabilities_subclient():

--- a/python/tests/test_sse.py
+++ b/python/tests/test_sse.py
@@ -23,6 +23,15 @@ class MockClient:
 
     _base_url = "https://api.example.com"
     _api_key = MockApiKey()
+    _org_id = "org_123"
+
+    def _auth_headers(self, *, content_type="application/json"):
+        headers = {"Authorization": self._api_key.value}
+        if content_type is not None:
+            headers["Content-Type"] = content_type
+        if self._org_id is not None:
+            headers["X-Org-Id"] = self._org_id
+        return headers
 
 
 class TestStreamOptions:
@@ -75,6 +84,21 @@ class TestStreamOptions:
         assert opts.since_id == "event_abc"
         assert opts.max_retries == 5
         assert opts.idle_timeout == 60
+
+
+class TestEventStreamHeaders:
+    """Tests for EventStream headers."""
+
+    def test_headers_include_org_id(self):
+        """Test SSE headers include organization ID."""
+        stream = EventStream(MockClient(), "session_123", StreamOptions())
+
+        assert stream._headers() == {
+            "Authorization": "test_key",
+            "X-Org-Id": "org_123",
+            "Accept": "text/event-stream",
+            "Cache-Control": "no-cache",
+        }
 
 
 class TestDisconnectingData:

--- a/rust/README.md
+++ b/rust/README.md
@@ -15,7 +15,7 @@ use everruns_sdk::{CreateSessionRequest, Everruns};
 
 #[tokio::main]
 async fn main() -> Result<(), everruns_sdk::Error> {
-    // Uses EVERRUNS_API_KEY environment variable
+    // Uses EVERRUNS_API_KEY and optional EVERRUNS_ORG_ID environment variables
     let client = Everruns::from_env()?;
 
     // Create an agent
@@ -62,14 +62,17 @@ Runnable example: [`examples/initial_files.rs`](examples/initial_files.rs)
 
 ## Authentication
 
-The SDK uses API key authentication. Set the \`EVERRUNS_API_KEY\` environment variable or pass the key explicitly:
+The SDK uses API key authentication. Set the \`EVERRUNS_API_KEY\` environment variable or pass the key explicitly. For API keys with access to multiple organizations, set \`EVERRUNS_ORG_ID\` or pass \`org_id\` explicitly:
 
 \`\`\`rust
 // From environment variable
 let client = Everruns::from_env()?;
 
-// Explicit key
-let client = Everruns::new("evr_...")?;
+// Explicit key and organization
+let client = Everruns::builder()
+    .api_key("evr_...")
+    .org_id("org_...")
+    .build()?;
 \`\`\`
 
 ## Streaming Events

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -14,36 +14,115 @@ pub struct Everruns {
     http: reqwest::Client,
     base_url: Url,
     api_key: ApiKey,
+    org_id: Option<HeaderValue>,
+}
+
+/// Builder for configuring an Everruns client.
+#[derive(Debug, Clone)]
+pub struct EverrunsBuilder {
+    api_key: Option<ApiKey>,
+    base_url: String,
+    org_id: Option<String>,
+}
+
+impl Default for EverrunsBuilder {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            base_url: DEFAULT_BASE_URL.to_string(),
+            org_id: std::env::var("EVERRUNS_ORG_ID")
+                .ok()
+                .filter(|org_id| !org_id.is_empty()),
+        }
+    }
+}
+
+impl EverrunsBuilder {
+    /// Set the API key.
+    pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = Some(ApiKey::new(api_key));
+        self
+    }
+
+    /// Set the API base URL.
+    pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// Set the organization id sent as `X-Org-Id` on every request.
+    pub fn org_id(mut self, org_id: impl Into<String>) -> Self {
+        self.org_id = Some(org_id.into());
+        self
+    }
+
+    /// Build the client.
+    pub fn build(self) -> Result<Everruns> {
+        let api_key = match self.api_key {
+            Some(api_key) => api_key,
+            None => ApiKey::from_env()?,
+        };
+        Everruns::with_api_key_url_and_org_id(api_key, &self.base_url, self.org_id)
+    }
 }
 
 impl Everruns {
+    /// Create a new client builder.
+    pub fn builder() -> EverrunsBuilder {
+        EverrunsBuilder::default()
+    }
+
     /// Create a new client with explicit API key
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
-        Self::with_base_url(api_key, DEFAULT_BASE_URL)
+        Self::builder().api_key(api_key).build()
     }
 
     /// Create a new client using environment variables.
     ///
     /// Reads `EVERRUNS_API_KEY` (required) and `EVERRUNS_API_URL` (optional).
     pub fn from_env() -> Result<Self> {
-        let api_key = ApiKey::from_env()?;
         let base_url =
             std::env::var("EVERRUNS_API_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
-        Self::with_api_key_and_url(api_key, &base_url)
+        Self::builder().base_url(base_url).build()
     }
 
     /// Create a new client with a custom base URL
     pub fn with_base_url(api_key: impl Into<String>, base_url: &str) -> Result<Self> {
-        let api_key = ApiKey::new(api_key);
-        Self::with_api_key_and_url(api_key, base_url)
+        Self::builder().api_key(api_key).base_url(base_url).build()
+    }
+
+    /// Create a new client with an organization id.
+    pub fn with_org_id(api_key: impl Into<String>, org_id: impl Into<String>) -> Result<Self> {
+        Self::builder().api_key(api_key).org_id(org_id).build()
+    }
+
+    /// Create a new client with a custom base URL and organization id.
+    pub fn with_base_url_and_org_id(
+        api_key: impl Into<String>,
+        base_url: &str,
+        org_id: impl Into<String>,
+    ) -> Result<Self> {
+        Self::builder()
+            .api_key(api_key)
+            .base_url(base_url)
+            .org_id(org_id)
+            .build()
     }
 
     /// Create a new client with an ApiKey instance
     pub fn with_api_key(api_key: ApiKey) -> Result<Self> {
-        Self::with_api_key_and_url(api_key, DEFAULT_BASE_URL)
+        Self::with_api_key_url_and_org_id(
+            api_key,
+            DEFAULT_BASE_URL,
+            EverrunsBuilder::default().org_id,
+        )
     }
 
-    fn with_api_key_and_url(api_key: ApiKey, base_url: &str) -> Result<Self> {
+    fn with_api_key_url_and_org_id(
+        api_key: ApiKey,
+        base_url: &str,
+        org_id: Option<String>,
+    ) -> Result<Self> {
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()?;
@@ -59,11 +138,21 @@ impl Everruns {
             format!("{}/", base_url)
         };
         let base_url = Url::parse(&normalized)?;
+        let org_id = org_id
+            .map(|org_id| {
+                if org_id.is_empty() {
+                    return Err(Error::Validation("org_id cannot be empty".to_string()));
+                }
+                HeaderValue::from_str(&org_id)
+                    .map_err(|err| Error::Validation(format!("invalid org_id header: {err}")))
+            })
+            .transpose()?;
 
         Ok(Self {
             http,
             base_url,
             api_key,
+            org_id,
         })
     }
 
@@ -115,12 +204,20 @@ impl Everruns {
         self.base_url.join(&full_path).expect("valid URL")
     }
 
-    fn headers(&self) -> HeaderMap {
+    pub(crate) fn auth_headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
             HeaderValue::from_str(self.api_key.expose()).expect("valid header"),
         );
+        if let Some(org_id) = &self.org_id {
+            headers.insert("X-Org-Id", org_id.clone());
+        }
+        headers
+    }
+
+    fn headers(&self) -> HeaderMap {
+        let mut headers = self.auth_headers();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
         headers
     }
@@ -315,10 +412,6 @@ impl Everruns {
             url.query_pairs_mut().append_pair("exclude", e);
         }
         url
-    }
-
-    pub(crate) fn auth_header(&self) -> String {
-        self.api_key.expose().to_string()
     }
 }
 
@@ -1043,6 +1136,10 @@ impl std::fmt::Debug for Everruns {
         f.debug_struct("Everruns")
             .field("base_url", &self.base_url.as_str())
             .field("api_key", &self.api_key)
+            .field(
+                "org_id",
+                &self.org_id.as_ref().and_then(|v| v.to_str().ok()),
+            )
             .finish()
     }
 }
@@ -1063,6 +1160,17 @@ mod tests {
             url.as_str(),
             "https://api.example.com/v1/sessions/session_123/sse"
         );
+    }
+
+    #[test]
+    fn test_sse_auth_headers_include_org_id() {
+        let client =
+            Everruns::with_base_url_and_org_id("test_key", "https://api.example.com", "org_123")
+                .unwrap();
+        let headers = client.auth_headers();
+
+        assert_eq!(headers["Authorization"], "test_key");
+        assert_eq!(headers["X-Org-Id"], "org_123");
     }
 
     #[test]

--- a/rust/src/sse.rs
+++ b/rust/src/sse.rs
@@ -258,7 +258,7 @@ impl EventStream {
 
             let mut es = http_client
                 .get(url.clone())
-                .header("Authorization", client.auth_header())
+                .headers(client.auth_headers())
                 .header("Accept", "text/event-stream")
                 .header("Cache-Control", "no-cache")
                 .eventsource()

--- a/rust/tests/client_test.rs
+++ b/rust/tests/client_test.rs
@@ -4,10 +4,13 @@ use everruns_sdk::{
     ContentPart, CreateAgentRequest, CreateBudgetRequest, CreateSessionRequest, Everruns,
     InitialFile, TopUpRequest, UpdateBudgetRequest,
 };
+use std::sync::Mutex;
 use wiremock::{
     Mock, MockServer, ResponseTemplate,
-    matchers::{body_json, method, path, query_param},
+    matchers::{body_json, header, method, path, query_param},
 };
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn test_client_creation() {
@@ -17,10 +20,55 @@ fn test_client_creation() {
 
 #[test]
 fn test_client_from_env_missing() {
+    let _guard = ENV_LOCK.lock().unwrap();
     // Ensure env var is not set
     // SAFETY: This test runs single-threaded and only removes a test-specific env var
     unsafe { std::env::remove_var("EVERRUNS_API_KEY") };
     let result = Everruns::from_env();
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_client_builder_with_org_id() {
+    let client = Everruns::builder()
+        .api_key("evr_test_key")
+        .org_id("org_123")
+        .build()
+        .expect("client creation should succeed");
+
+    let debug_str = format!("{:?}", client);
+    assert!(debug_str.contains("org_123"));
+}
+
+#[test]
+fn test_client_from_env_reads_org_id() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    // SAFETY: This test serializes access to process env within this test file.
+    unsafe {
+        std::env::set_var("EVERRUNS_API_KEY", "evr_from_env");
+        std::env::set_var("EVERRUNS_ORG_ID", "org_from_env");
+    }
+
+    let result = Everruns::from_env();
+
+    // SAFETY: This test serializes access to process env within this test file.
+    unsafe {
+        std::env::remove_var("EVERRUNS_API_KEY");
+        std::env::remove_var("EVERRUNS_ORG_ID");
+    }
+
+    let client = result.expect("client creation should succeed");
+    let debug_str = format!("{:?}", client);
+    assert!(debug_str.contains("org_from_env"));
+}
+
+#[test]
+fn test_client_org_id_rejects_invalid_header_value() {
+    let result = Everruns::builder()
+        .api_key("evr_test_key")
+        .org_id("bad\norg")
+        .build();
+
     assert!(result.is_err());
 }
 
@@ -56,6 +104,28 @@ fn test_base_url_normalization_preserves_trailing_slash() {
         debug_str.contains("https://custom.example.com/api/"),
         "base URL with trailing slash should be preserved"
     );
+}
+
+#[tokio::test]
+async fn test_client_sends_org_id_header() {
+    let server = MockServer::start().await;
+    let client = Everruns::with_base_url_and_org_id("evr_test_key", &server.uri(), "org_123")
+        .expect("client");
+
+    Mock::given(method("GET"))
+        .and(path("/v1/agents"))
+        .and(header("X-Org-Id", "org_123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [],
+            "total": 0,
+            "offset": 0,
+            "limit": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let response = client.agents().list().await.expect("agents list");
+    assert_eq!(response.data.len(), 0);
 }
 
 #[tokio::test]

--- a/specs/auth.md
+++ b/specs/auth.md
@@ -1,19 +1,22 @@
 # Authentication
 
-## EVERRUNS_API_KEY
+## API Key And Organization Context
 
-All SDKs use `EVERRUNS_API_KEY` environment variable as default.
+All SDKs use `EVERRUNS_API_KEY` as the default API key source. Multi-org API-key users can set organization context with `EVERRUNS_ORG_ID` or an explicit client option. Explicit client options take precedence over the environment.
 
 ### Rust
 
 ```rust
 use everruns_sdk::Everruns;
 
-// From environment
-let client = Everruns::from_env("my-org")?;
+// From environment: EVERRUNS_API_KEY, optional EVERRUNS_API_URL, optional EVERRUNS_ORG_ID
+let client = Everruns::from_env()?;
 
 // Explicit
-let client = Everruns::new("evr_...", "my-org");
+let client = Everruns::builder()
+    .api_key("evr_...")
+    .org_id("org_...")
+    .build()?;
 ```
 
 ### Python
@@ -21,11 +24,11 @@ let client = Everruns::new("evr_...", "my-org");
 ```python
 from everruns_sdk import Everruns
 
-# From environment
-client = Everruns(org="my-org")
+# From environment: EVERRUNS_API_KEY, optional EVERRUNS_API_URL, optional EVERRUNS_ORG_ID
+client = Everruns()
 
 # Explicit
-client = Everruns(api_key="evr_...", org="my-org")
+client = Everruns(api_key="evr_...", org_id="org_...")
 ```
 
 ### TypeScript
@@ -33,17 +36,18 @@ client = Everruns(api_key="evr_...", org="my-org")
 ```typescript
 import { Everruns } from "@everruns/sdk";
 
-// From environment
-const client = Everruns.fromEnv("my-org");
+// From environment: EVERRUNS_API_KEY, optional EVERRUNS_API_URL, optional EVERRUNS_ORG_ID
+const client = Everruns.fromEnv();
 
 // Explicit
-const client = new Everruns({ apiKey: "evr_...", org: "my-org" });
+const client = new Everruns({ apiKey: "evr_...", orgId: "org_..." });
 ```
 
 ## Auth Header Format
 
 ```
 Authorization: <api_key>
+X-Org-Id: <org_id>
 ```
 
-No Bearer prefix for API keys. Keys start with `evr_` prefix.
+No Bearer prefix for API keys. Keys start with `evr_` prefix. `X-Org-Id` is optional for single-org accounts and required by the API when an API key has access to multiple organizations.

--- a/specs/cookbooks.md
+++ b/specs/cookbooks.md
@@ -46,6 +46,7 @@ Each language must implement the "Dad Jokes Agent" demonstrating:
 |----------|----------|-------------|
 | `EVERRUNS_API_KEY` | Yes | API key for authentication |
 | `EVERRUNS_API_URL` | No | Override base URL (default: production) |
+| `EVERRUNS_ORG_ID` | No | Organization ID for multi-org API keys |
 
 ### Agent Configuration
 

--- a/specs/sdk-features.md
+++ b/specs/sdk-features.md
@@ -14,6 +14,7 @@ Everruns SDKs provide typed clients for the Everruns API. All language implement
 |-----------|--------------|-------------|
 | `api_key` | `EVERRUNS_API_KEY` | API key |
 | `api_url` | `EVERRUNS_API_URL` | API base URL (optional, for testing/self-hosted) |
+| `org_id` | `EVERRUNS_ORG_ID` | Organization ID for multi-org API keys (optional) |
 
 All parameters can be omitted if the corresponding environment variable is set.
 
@@ -25,6 +26,9 @@ client = Everruns()
 
 # Explicit API key
 client = Everruns(api_key="evr_...")
+
+# Explicit API key and organization
+client = Everruns(api_key="evr_...", org_id="org_...")
 
 # Custom base URL
 client = Everruns(api_url="https://custom.example.com/api")

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -13,7 +13,7 @@ npm install @everruns/sdk
 \`\`\`typescript
 import { Everruns } from "@everruns/sdk";
 
-// Uses EVERRUNS_API_KEY environment variable
+// Uses EVERRUNS_API_KEY and optional EVERRUNS_ORG_ID environment variables
 const client = Everruns.fromEnv();
 
 // Create an agent
@@ -60,15 +60,16 @@ Run locally from this repo with `npx tsx examples/initial-files.ts`.
 
 ## Authentication
 
-The SDK uses API key authentication. Set the \`EVERRUNS_API_KEY\` environment variable or pass the key explicitly:
+The SDK uses API key authentication. Set the \`EVERRUNS_API_KEY\` environment variable or pass the key explicitly. For API keys with access to multiple organizations, set \`EVERRUNS_ORG_ID\` or pass \`orgId\` explicitly:
 
 \`\`\`typescript
 // From environment variable
 const client = Everruns.fromEnv();
 
-// Explicit key
+// Explicit key and organization
 const client = new Everruns({
-apiKey: "evr\_..."
+apiKey: "evr\_...",
+orgId: "org\_..."
 });
 \`\`\`
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -38,17 +38,20 @@ import {
   AuthenticationError,
   NotFoundError,
   RateLimitError,
+  ValidationError,
 } from "./errors.js";
 import { EventStream } from "./sse.js";
 
 export interface EverrunsOptions {
   apiKey?: string | ApiKey;
   baseUrl?: string;
+  orgId?: string;
 }
 
 export class Everruns {
   private readonly apiKey: ApiKey;
   private readonly baseUrl: string;
+  private readonly orgId?: string;
 
   readonly agents: AgentsClient;
   readonly sessions: SessionsClient;
@@ -73,6 +76,11 @@ export class Everruns {
     //          "http://host/api" + "/v1/agents" = "http://host/api/v1/agents" (correct)
     const rawBaseUrl = options.baseUrl ?? "https://custom.example.com/api";
     this.baseUrl = rawBaseUrl.replace(/\/+$/, "");
+    const orgId =
+      options.orgId !== undefined
+        ? options.orgId
+        : process.env.EVERRUNS_ORG_ID || undefined;
+    this.orgId = validateOrgId(orgId);
 
     this.agents = new AgentsClient(this);
     this.sessions = new SessionsClient(this);
@@ -88,10 +96,12 @@ export class Everruns {
    * Create a client using environment variables.
    *
    * Reads `EVERRUNS_API_KEY` (required) and `EVERRUNS_API_URL` (optional).
+   * Reads `EVERRUNS_ORG_ID` when present.
    */
   static fromEnv(): Everruns {
     const baseUrl = process.env.EVERRUNS_API_URL;
-    return new Everruns({ baseUrl });
+    const orgId = process.env.EVERRUNS_ORG_ID || undefined;
+    return new Everruns({ baseUrl, orgId });
   }
 
   /**
@@ -109,8 +119,7 @@ export class Everruns {
     const response = await fetch(url, {
       ...options,
       headers: {
-        Authorization: this.apiKey.toHeader(),
-        "Content-Type": "application/json",
+        ...this.authHeaders("application/json"),
         ...options.headers,
       },
     });
@@ -150,7 +159,7 @@ export class Everruns {
     const response = await fetch(url, {
       ...options,
       headers: {
-        Authorization: this.apiKey.toHeader(),
+        ...this.authHeaders(),
         ...options.headers,
       },
     });
@@ -183,6 +192,37 @@ export class Everruns {
   getAuthHeader(): string {
     return this.apiKey.toHeader();
   }
+
+  getOrgId(): string | undefined {
+    return this.orgId;
+  }
+
+  private authHeaders(contentType?: string): Record<string, string> {
+    const headers: Record<string, string> = {
+      Authorization: this.apiKey.toHeader(),
+    };
+    if (contentType !== undefined) {
+      headers["Content-Type"] = contentType;
+    }
+    if (this.orgId !== undefined) {
+      headers["X-Org-Id"] = this.orgId;
+    }
+    return headers;
+  }
+}
+
+function validateOrgId(orgId: string | undefined): string | undefined {
+  if (orgId === undefined) return undefined;
+  if (orgId.length === 0) {
+    throw new ValidationError("orgId cannot be empty");
+  }
+  try {
+    new Headers({ "X-Org-Id": orgId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(`Invalid orgId header: ${message}`);
+  }
+  return orgId;
 }
 
 class AgentsClient {
@@ -554,7 +594,12 @@ class EventsClient {
   stream(sessionId: string, options?: StreamOptions): EventStream {
     // Build base URL (without since_id - EventStream handles that for reconnection)
     const url = this.client.getStreamUrl(`/sessions/${sessionId}/sse`);
-    return new EventStream(url, this.client.getAuthHeader(), options);
+    return new EventStream(
+      url,
+      this.client.getAuthHeader(),
+      options,
+      this.client.getOrgId(),
+    );
   }
 }
 

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -45,6 +45,13 @@ export class RateLimitError extends ApiError {
   }
 }
 
+export class ValidationError extends EverrunsError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
 export class ConnectionError extends EverrunsError {
   constructor(message: string = "Connection failed") {
     super(message);

--- a/typescript/src/sse.ts
+++ b/typescript/src/sse.ts
@@ -54,6 +54,7 @@ export interface DisconnectingData {
 export class EventStream implements AsyncIterable<Event> {
   private readonly baseUrl: string;
   private readonly authHeader: string;
+  private readonly orgId?: string;
   private readonly options: StreamOptions;
   private lastEventId?: string;
   private abortController?: AbortController;
@@ -63,9 +64,15 @@ export class EventStream implements AsyncIterable<Event> {
   private shouldReconnect: boolean = true;
   private gracefulDisconnect: boolean = false;
 
-  constructor(url: string, authHeader: string, options: StreamOptions = {}) {
+  constructor(
+    url: string,
+    authHeader: string,
+    options: StreamOptions = {},
+    orgId?: string,
+  ) {
     this.baseUrl = url;
     this.authHeader = authHeader;
+    this.orgId = orgId;
     this.options = options;
     this.lastEventId = options.sinceId;
   }
@@ -139,6 +146,10 @@ export class EventStream implements AsyncIterable<Event> {
   private resetBackoff(): void {
     this.currentBackoffMs = INITIAL_BACKOFF_MS;
     this.retryCount = 0;
+  }
+
+  private orgHeaders(): Record<string, string> {
+    return this.orgId === undefined ? {} : { "X-Org-Id": this.orgId };
   }
 
   private shouldRetry(): boolean {
@@ -233,6 +244,7 @@ export class EventStream implements AsyncIterable<Event> {
       const response = await fetch(url, {
         headers: {
           Authorization: this.authHeader,
+          ...this.orgHeaders(),
           Accept: "text/event-stream",
           "Cache-Control": "no-cache",
         },

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApiKey } from "../src/auth.js";
 import { Everruns } from "../src/client.js";
+import { ValidationError } from "../src/errors.js";
 import {
   generateAgentId,
   generateHarnessId,
@@ -31,6 +32,7 @@ import {
 } from "../src/models.js";
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
@@ -65,6 +67,44 @@ describe("Everruns", () => {
       apiKey,
     });
     expect(client).toBeDefined();
+  });
+
+  it("should create client with explicit org ID", () => {
+    const client = new Everruns({
+      apiKey: "evr_test_key",
+      orgId: "org_123",
+    });
+    expect(client.getOrgId()).toBe("org_123");
+  });
+
+  it("should read org ID from environment", () => {
+    vi.stubEnv("EVERRUNS_API_KEY", "evr_from_env");
+    vi.stubEnv("EVERRUNS_ORG_ID", "org_from_env");
+
+    const client = Everruns.fromEnv();
+
+    expect(client.getOrgId()).toBe("org_from_env");
+  });
+
+  it("should prefer explicit org ID over environment", () => {
+    vi.stubEnv("EVERRUNS_ORG_ID", "org_from_env");
+
+    const client = new Everruns({
+      apiKey: "evr_test_key",
+      orgId: "org_explicit",
+    });
+
+    expect(client.getOrgId()).toBe("org_explicit");
+  });
+
+  it("should reject invalid org ID header values", () => {
+    expect(
+      () =>
+        new Everruns({
+          apiKey: "evr_test_key",
+          orgId: "bad\norg",
+        }),
+    ).toThrow(ValidationError);
   });
 
   it("should use custom base URL", () => {
@@ -141,6 +181,37 @@ describe("Everruns", () => {
         headers: expect.objectContaining({
           Authorization: "evr_test_key",
           "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("should send org ID header on requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [],
+        total: 0,
+        offset: 0,
+        limit: 0,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new Everruns({
+      apiKey: "evr_test_key",
+      orgId: "org_123",
+    });
+
+    await client.agents.list();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://custom.example.com/api/v1/agents",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "evr_test_key",
+          "X-Org-Id": "org_123",
         }),
       }),
     );

--- a/typescript/tests/sse.test.ts
+++ b/typescript/tests/sse.test.ts
@@ -28,6 +28,16 @@ describe("EventStream", () => {
       });
       expect(stream.getLastEventId()).toBe("event_abc");
     });
+
+    it("should include org ID in headers", () => {
+      const stream = new EventStream(
+        "https://api.example.com/sse",
+        "auth",
+        {},
+        "org_123",
+      );
+      expect((stream as any).orgHeaders()).toEqual({ "X-Org-Id": "org_123" });
+    });
   });
 
   describe("abort", () => {


### PR DESCRIPTION
## Summary

- Add first-class `X-Org-Id` support across Rust, Python, and TypeScript clients.
- Read `EVERRUNS_ORG_ID` from env with explicit client options taking precedence.
- Forward org context on normal requests and SSE streams; document the new API.

Closes #82

## Test Plan

- [x] `just test`
- [x] `just lint`
- [x] `just pre-pr`
- [x] `just pre-push`
- [x] `just check-cookbook`

- [x] Tests pass locally
- [x] Coverage ≥80%
- [x] Linting passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)