### PR TITLE
chore(release): prepare v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.9] - 2026-05-08
+
+### Highlights
+
+- Agent version APIs across Rust, Python, and TypeScript SDKs
+- First-class org context support via `X-Org-Id` and `EVERRUNS_ORG_ID`
+- Refreshed generated schemas, agent stats support, and maintenance updates
+
+### What's Changed
+
+* feat: adopt upstream agent versions ([#87](https://github.com/everruns/sdk/pull/87)) by @chaliy
+* feat: add org context support across SDKs ([#86](https://github.com/everruns/sdk/pull/86)) by @chaliy
+* chore(docs): add upstream adoption skill ([#85](https://github.com/everruns/sdk/pull/85)) by @chaliy
+* chore(docs): make agent skills canonical ([#84](https://github.com/everruns/sdk/pull/84)) by @chaliy
+* chore: periodic maintenance ([#83](https://github.com/everruns/sdk/pull/83)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/sdk/compare/v0.1.8...v0.1.9
+
 ## [0.1.8] - 2026-04-15
 
 ### Highlights

--- a/python/everruns_sdk/__init__.py
+++ b/python/everruns_sdk/__init__.py
@@ -112,4 +112,4 @@ __all__ = [
     "validate_harness_name",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "everruns-sdk"
-version = "0.1.8"
+version = "0.1.9"
 description = "Python SDK for Everruns API"
 readme = "README.md"
 license = "MIT"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -172,7 +172,7 @@ toml = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-stream",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-sdk"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "Rust SDK for Everruns API"
 license = "MIT"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/sdk",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "TypeScript SDK for Everruns API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Prepare v0.1.9 across Rust, Python, and TypeScript package manifests.
- Add v0.1.9 changelog notes for PRs #83-#87.
- Sync Python __version__ with the package release version.

## Test Plan

- [x] Tests pass locally: `just release-check`
- [x] Coverage ≥80%: existing suite maintained; release-only change
- [x] Linting passes: `just pre-push`

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable)
- [x] Added/updated tests (not applicable, release-only)
- [x] Updated documentation (CHANGELOG.md)
