### PR TITLE
docs(rust,python,typescript): document workspaces and memories APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,12 @@ jobs:
       - name: Install Python SDK deps
         run: cd python && uv sync --all-extras
       - name: Check Python examples syntax
-        run: cd python && uv run python -m py_compile examples/basic.py examples/initial_files.py
+        run: cd python && uv run python -m py_compile examples/basic.py examples/initial_files.py examples/workspaces.py examples/memories.py
 
       - name: Install TypeScript SDK deps
         run: cd typescript && npm ci
       - name: Check TypeScript examples compile
-        run: cd typescript && npx tsc --noEmit --ignoreConfig --types node examples/basic.ts examples/initial-files.ts
+        run: cd typescript && npx tsc --noEmit --ignoreConfig --types node examples/basic.ts examples/initial-files.ts examples/workspaces.ts examples/memories.ts
 
   check-cookbooks:
     runs-on: ubuntu-latest

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -22,7 +22,7 @@ Workspaces hold files shared across sessions; memories are long-term,
 searchable knowledge stores for agents. Runnable, single-file examples live in
 each SDK's `examples/` directory:
 
-| | Workspaces | Memories |
+| SDK | Workspaces | Memories |
 |---|---|---|
 | Rust | `cargo run --example workspaces` | `cargo run --example memories` |
 | Python | `uv run python examples/workspaces.py` | `uv run python examples/memories.py` |

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -15,3 +15,15 @@ DEV_MODE=1 everruns-server
 - [rust/](rust/) - Rust SDK example
 - [python/](python/) - Python SDK example
 - [typescript/](typescript/) - TypeScript SDK example
+
+## Workspaces & Memories
+
+Workspaces hold files shared across sessions; memories are long-term,
+searchable knowledge stores for agents. Runnable, single-file examples live in
+each SDK's `examples/` directory:
+
+| | Workspaces | Memories |
+|---|---|---|
+| Rust | `cargo run --example workspaces` | `cargo run --example memories` |
+| Python | `uv run python examples/workspaces.py` | `uv run python examples/memories.py` |
+| TypeScript | `npx tsx examples/workspaces.ts` | `npx tsx examples/memories.ts` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,6 +86,38 @@ async for event in client.events.stream(session.id):
         print(event.data.message.content)
 ```
 
+### 7. Workspaces
+
+Workspaces hold files shared across sessions.
+
+```python
+workspace = await client.workspaces.create(name="team-docs")
+
+await client.workspace_files.create(
+    workspace.id,
+    "/notes/welcome.md",
+    "# Welcome\n",
+    encoding="text",
+)
+files = await client.workspace_files.list(workspace.id, recursive=True)
+```
+
+### 8. Memories
+
+Memories are long-term, searchable knowledge stores for agents.
+
+```python
+memory = await client.memories.create(name="product-knowledge")
+
+await client.memories.create_file(
+    memory.id,
+    "/facts/product.md",
+    "# Product\n",
+    encoding="text",
+)
+results = await client.memories.grep_files(memory.id, "product")
+```
+
 ## Next Steps
 
 - See `cookbook/` for practical recipes

--- a/justfile
+++ b/justfile
@@ -33,12 +33,12 @@ check-examples-rust:
 
 # Check Python examples
 check-examples-python:
-    cd python && uv run python -m py_compile examples/basic.py examples/initial_files.py
+    cd python && uv run python -m py_compile examples/basic.py examples/initial_files.py examples/workspaces.py examples/memories.py
 
 # Check TypeScript examples
 check-examples-typescript:
     cd typescript && npm run build
-    cd typescript && npx tsc --noEmit --ignoreConfig --types node examples/basic.ts examples/initial-files.ts
+    cd typescript && npx tsc --noEmit --ignoreConfig --types node examples/basic.ts examples/initial-files.ts examples/workspaces.ts examples/memories.ts
 
 # Lint all SDKs
 lint: lint-rust lint-python lint-typescript

--- a/python/README.md
+++ b/python/README.md
@@ -103,6 +103,44 @@ rollback = await client.agents.rollback_version(
 )
 ```
 
+## Workspaces
+
+Workspaces hold files shared across sessions.
+
+```python
+workspace = await client.workspaces.create(name="team-docs")
+
+await client.workspace_files.create(
+    workspace.id,
+    "/notes/welcome.md",
+    "# Welcome\n",
+    encoding="text",
+)
+file = await client.workspace_files.read(workspace.id, "/notes/welcome.md")
+files = await client.workspace_files.list(workspace.id, recursive=True)
+```
+
+Runnable example: [`examples/workspaces.py`](examples/workspaces.py)
+
+## Memories
+
+Memories are long-term, searchable knowledge stores for agents.
+
+```python
+memory = await client.memories.create(name="product-knowledge")
+
+await client.memories.create_file(
+    memory.id,
+    "/facts/product.md",
+    "# Product\n",
+    encoding="text",
+)
+results = await client.memories.grep_files(memory.id, "product")
+await client.memories.sync(memory.id)
+```
+
+Runnable example: [`examples/memories.py`](examples/memories.py)
+
 ## License
 
 MIT

--- a/python/examples/memories.py
+++ b/python/examples/memories.py
@@ -1,0 +1,42 @@
+"""Example: create a memory, add files, and search them.
+
+Run with:
+    EVERRUNS_API_KEY=evr_... uv run python examples/memories.py
+"""
+
+import asyncio
+
+from everruns_sdk import Everruns
+
+
+async def main():
+    client = Everruns()
+
+    try:
+        memory = await client.memories.create(
+            name="memories-example-py",
+            description="Long-term knowledge for the agent",
+        )
+        print(f"Created memory {memory.id}")
+
+        await client.memories.create_file(
+            memory.id,
+            "/facts/product.md",
+            "# Product\n\nEverruns runs autonomous agents.\n",
+            encoding="text",
+        )
+
+        results = await client.memories.grep_files(memory.id, "agents")
+        print(f"Found {len(results)} match(es) for 'agents'")
+
+        files = await client.memories.list_files(memory.id)
+        print(f"Memory has {len(files)} file(s)")
+
+        await client.memories.delete(memory.id)
+        print("Archived memory")
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/examples/workspaces.py
+++ b/python/examples/workspaces.py
@@ -1,0 +1,43 @@
+"""Example: create a workspace and manage its files.
+
+Run with:
+    EVERRUNS_API_KEY=evr_... uv run python examples/workspaces.py
+"""
+
+import asyncio
+
+from everruns_sdk import Everruns
+
+
+async def main():
+    client = Everruns()
+
+    try:
+        workspace = await client.workspaces.create(
+            name="workspaces-example-py",
+            description="Shared files for the team",
+        )
+        print(f"Created workspace {workspace.id}")
+
+        await client.workspace_files.create(
+            workspace.id,
+            "/notes/welcome.md",
+            "# Welcome\n\nShared workspace files live here.\n",
+            encoding="text",
+        )
+
+        file = await client.workspace_files.read(workspace.id, "/notes/welcome.md")
+        print(f"Read {file.path}:")
+        print(file.content)
+
+        files = await client.workspace_files.list(workspace.id, recursive=True)
+        print(f"Workspace has {len(files)} file(s)")
+
+        await client.workspaces.delete(workspace.id)
+        print("Archived workspace")
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/rust/README.md
+++ b/rust/README.md
@@ -4,13 +4,13 @@ Rust SDK for the Everruns API.
 
 ## Installation
 
-\`\`\`bash
+```bash
 cargo add everruns-sdk
-\`\`\`
+```
 
 ## Quick Start
 
-\`\`\`rust
+```rust
 use everruns_sdk::{CreateSessionRequest, Everruns};
 
 #[tokio::main]
@@ -35,11 +35,11 @@ async fn main() -> Result<(), everruns_sdk::Error> {
 
     Ok(())
 }
-\`\`\`
+```
 
 ## Initial Files
 
-\`\`\`rust
+```rust
 use everruns_sdk::{CreateSessionRequest, InitialFile};
 
 let session = client
@@ -56,13 +56,13 @@ let session = client
             ]),
     )
     .await?;
-\`\`\`
+```
 
 Runnable example: [`examples/initial_files.rs`](examples/initial_files.rs)
 
 ## Agent Versions
 
-\`\`\`rust
+```rust
 use everruns_sdk::{AgentVersionChangeKind, CreateAgentVersionRequest};
 
 let version = client
@@ -80,13 +80,63 @@ let diff = client
     .agents()
     .diff_versions("agent_...", "agentver_1", &version.id)
     .await?;
-\`\`\`
+```
+
+## Workspaces
+
+Workspaces hold files shared across sessions.
+
+```rust
+use everruns_sdk::CreateWorkspaceRequest;
+
+let workspace = client
+    .workspaces()
+    .create(CreateWorkspaceRequest::new("team-docs"))
+    .await?;
+
+client
+    .workspace_files()
+    .create(&workspace.id, "/notes/welcome.md", "# Welcome\n", Some("text"))
+    .await?;
+let file = client
+    .workspace_files()
+    .read(&workspace.id, "/notes/welcome.md")
+    .await?;
+let files = client
+    .workspace_files()
+    .list(&workspace.id, None, Some(true))
+    .await?;
+```
+
+Runnable example: [`examples/workspaces.rs`](examples/workspaces.rs)
+
+## Memories
+
+Memories are long-term, searchable knowledge stores for agents.
+
+```rust
+use everruns_sdk::CreateMemoryRequest;
+
+let memory = client
+    .memories()
+    .create(CreateMemoryRequest::new("product-knowledge"))
+    .await?;
+
+client
+    .memories()
+    .create_file(&memory.id, "/facts/product.md", "# Product\n", Some("text"))
+    .await?;
+let results = client.memories().grep_files(&memory.id, "product", None).await?;
+client.memories().sync(&memory.id).await?;
+```
+
+Runnable example: [`examples/memories.rs`](examples/memories.rs)
 
 ## Authentication
 
-The SDK uses personal access token authentication. Set the \`EVERRUNS_API_KEY\` environment variable or pass the token explicitly. For personal access tokens with access to multiple organizations, set \`EVERRUNS_ORG_ID\` or pass \`org_id\` explicitly:
+The SDK uses personal access token authentication. Set the `EVERRUNS_API_KEY` environment variable or pass the token explicitly. For personal access tokens with access to multiple organizations, set `EVERRUNS_ORG_ID` or pass `org_id` explicitly:
 
-\`\`\`rust
+```rust
 // From environment variable
 let client = Everruns::from_env()?;
 
@@ -95,13 +145,13 @@ let client = Everruns::builder()
     .api_key("evr_pat_...")
     .org_id("org_...")
     .build()?;
-\`\`\`
+```
 
 ## Streaming Events
 
 The SDK supports SSE streaming with automatic reconnection:
 
-\`\`\`rust
+```rust
 use futures::StreamExt;
 use everruns_sdk::StreamOptions;
 
@@ -126,11 +176,11 @@ while let Some(event) = stream.next().await {
         _ => {}
     }
 }
-\`\`\`
+```
 
 ## Error Handling
 
-\`\`\`rust
+```rust
 use everruns_sdk::Error;
 
 match client.agents().get("invalid-id").await {
@@ -142,7 +192,7 @@ match client.agents().get("invalid-id").await {
     }
     Err(e) => eprintln!("Error: {}", e),
 }
-\`\`\`
+```
 
 ## License
 

--- a/rust/examples/memories.rs
+++ b/rust/examples/memories.rs
@@ -1,0 +1,44 @@
+//! Example: create a memory, add files, and search them
+//!
+//! Run with:
+//! `EVERRUNS_API_KEY=evr_... cargo run --example memories`
+
+use everruns_sdk::{CreateMemoryRequest, Error, Everruns};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let client = Everruns::from_env()?;
+
+    let memory = client
+        .memories()
+        .create(
+            CreateMemoryRequest::new("memories-example-rs")
+                .description("Long-term knowledge for the agent"),
+        )
+        .await?;
+    println!("Created memory {}", memory.id);
+
+    client
+        .memories()
+        .create_file(
+            &memory.id,
+            "/facts/product.md",
+            "# Product\n\nEverruns runs autonomous agents.\n",
+            Some("text"),
+        )
+        .await?;
+
+    let results = client
+        .memories()
+        .grep_files(&memory.id, "agents", None)
+        .await?;
+    println!("Found {} match(es) for 'agents'", results.data.len());
+
+    let files = client.memories().list_files(&memory.id).await?;
+    println!("Memory has {} file(s)", files.data.len());
+
+    client.memories().delete(&memory.id).await?;
+    println!("Archived memory");
+
+    Ok(())
+}

--- a/rust/examples/workspaces.rs
+++ b/rust/examples/workspaces.rs
@@ -1,0 +1,48 @@
+//! Example: create a workspace and manage its files
+//!
+//! Run with:
+//! `EVERRUNS_API_KEY=evr_... cargo run --example workspaces`
+
+use everruns_sdk::{CreateWorkspaceRequest, Error, Everruns};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let client = Everruns::from_env()?;
+
+    let workspace = client
+        .workspaces()
+        .create(
+            CreateWorkspaceRequest::new("workspaces-example-rs")
+                .description("Shared files for the team"),
+        )
+        .await?;
+    println!("Created workspace {}", workspace.id);
+
+    client
+        .workspace_files()
+        .create(
+            &workspace.id,
+            "/notes/welcome.md",
+            "# Welcome\n\nShared workspace files live here.\n",
+            Some("text"),
+        )
+        .await?;
+
+    let file = client
+        .workspace_files()
+        .read(&workspace.id, "/notes/welcome.md")
+        .await?;
+    println!("Read {}:", file.path);
+    println!("{}", file.content.unwrap_or_default());
+
+    let files = client
+        .workspace_files()
+        .list(&workspace.id, None, Some(true))
+        .await?;
+    println!("Workspace has {} file(s)", files.data.len());
+
+    client.workspaces().delete(&workspace.id).await?;
+    println!("Archived workspace");
+
+    Ok(())
+}

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -166,9 +166,9 @@ await client.agents.get("invalid-id");
 if (error instanceof AuthenticationError) {
 console.error("Invalid personal access token");
 } else if (error instanceof RateLimitError) {
-console.log(`Retry after \${error.retryAfter} seconds`);
+console.log(`Retry after ${error.retryAfter} seconds`);
 } else if (error instanceof ApiError) {
-console.error(`API error \${error.statusCode}: \${error.message}`);
+console.error(`API error ${error.statusCode}: ${error.message}`);
 }
 }
 ```

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -4,13 +4,13 @@ TypeScript SDK for the Everruns API.
 
 ## Installation
 
-\`\`\`bash
+```bash
 npm install @everruns/sdk
-\`\`\`
+```
 
 ## Quick Start
 
-\`\`\`typescript
+```typescript
 import { Everruns } from "@everruns/sdk";
 
 // Uses EVERRUNS_API_KEY and optional EVERRUNS_ORG_ID environment variables
@@ -32,13 +32,13 @@ await client.messages.create(session.id, "Hello!");
 for await (const event of client.events.stream(session.id)) {
 console.log(event.type, event.data);
 }
-\`\`\`
+```
 
 ## Initial Files
 
-\`\`\`typescript
+```typescript
 const session = await client.sessions.create({
-agentId: "agent\_...",
+agentId: "agent_...",
 initialFiles: [
 {
 path: "/workspace/README.md",
@@ -53,14 +53,14 @@ encoding: "text",
 },
 ],
 });
-\`\`\`
+```
 
 Runnable example: [`examples/initial-files.ts`](examples/initial-files.ts)
 Run locally from this repo with `npx tsx examples/initial-files.ts`.
 
 ## Agent Versions
 
-\`\`\`typescript
+```typescript
 const version = await client.agents.createVersion("agent_...", {
 changeKind: "manual",
 summary: "Baseline",
@@ -74,31 +74,69 @@ name: "forked-agent",
 const rollback = await client.agents.rollbackVersion("agent_...", version.id, {
 saveVersion: true,
 });
-\`\`\`
+```
+
+## Workspaces
+
+Workspaces hold files shared across sessions.
+
+```typescript
+const workspace = await client.workspaces.create({ name: "team-docs" });
+
+await client.workspaceFiles.create(
+workspace.id,
+"/notes/welcome.md",
+"# Welcome\n",
+{ encoding: "text" },
+);
+const file = await client.workspaceFiles.read(workspace.id, "/notes/welcome.md");
+const files = await client.workspaceFiles.list(workspace.id, { recursive: true });
+```
+
+Runnable example: [`examples/workspaces.ts`](examples/workspaces.ts)
+Run locally from this repo with `npx tsx examples/workspaces.ts`.
+
+## Memories
+
+Memories are long-term, searchable knowledge stores for agents.
+
+```typescript
+const memory = await client.memories.create({ name: "product-knowledge" });
+
+await client.memories.createFile(memory.id, "/facts/product.md", {
+content: "# Product\n",
+encoding: "text",
+});
+const results = await client.memories.grepFiles(memory.id, "product");
+await client.memories.sync(memory.id);
+```
+
+Runnable example: [`examples/memories.ts`](examples/memories.ts)
+Run locally from this repo with `npx tsx examples/memories.ts`.
 
 ## Authentication
 
-The SDK uses personal access token authentication. Set the \`EVERRUNS_API_KEY\` environment variable or pass the token explicitly. For personal access tokens with access to multiple organizations, set \`EVERRUNS_ORG_ID\` or pass \`orgId\` explicitly:
+The SDK uses personal access token authentication. Set the `EVERRUNS_API_KEY` environment variable or pass the token explicitly. For personal access tokens with access to multiple organizations, set `EVERRUNS_ORG_ID` or pass `orgId` explicitly:
 
-\`\`\`typescript
+```typescript
 // From environment variable
 const client = Everruns.fromEnv();
 
 // Explicit token and organization
 const client = new Everruns({
-apiKey: "evr\_pat\_...",
-orgId: "org\_..."
+apiKey: "evr_pat_...",
+orgId: "org_..."
 });
-\`\`\`
+```
 
 ## Streaming Events
 
 The SDK supports SSE streaming with automatic reconnection:
 
-\`\`\`typescript
+```typescript
 const stream = client.events.stream(session.id, {
 exclude: ["output.message.delta"], // Filter out delta events
-sinceId: "evt\_..." // Resume from event ID
+sinceId: "evt_..." // Resume from event ID
 });
 
 for await (const event of stream) {
@@ -115,11 +153,11 @@ console.error("Turn failed:", event.data);
 break;
 }
 }
-\`\`\`
+```
 
 ## Error Handling
 
-\`\`\`typescript
+```typescript
 import { ApiError, AuthenticationError, RateLimitError } from "@everruns/sdk";
 
 try {
@@ -128,12 +166,12 @@ await client.agents.get("invalid-id");
 if (error instanceof AuthenticationError) {
 console.error("Invalid personal access token");
 } else if (error instanceof RateLimitError) {
-console.log(\`Retry after \${error.retryAfter} seconds\`);
+console.log(`Retry after \${error.retryAfter} seconds`);
 } else if (error instanceof ApiError) {
-console.error(\`API error \${error.statusCode}: \${error.message}\`);
+console.error(`API error \${error.statusCode}: \${error.message}`);
 }
 }
-\`\`\`
+```
 
 ## License
 

--- a/typescript/examples/memories.ts
+++ b/typescript/examples/memories.ts
@@ -1,0 +1,34 @@
+/**
+ * Example: create a memory, add files, and search them.
+ *
+ * Run with:
+ * `EVERRUNS_API_KEY=evr_... npx tsx examples/memories.ts`
+ */
+
+import { Everruns } from "../src/index.js";
+
+async function main() {
+  const client = Everruns.fromEnv();
+
+  const memory = await client.memories.create({
+    name: "memories-example-ts",
+    description: "Long-term knowledge for the agent",
+  });
+  console.log("Created memory", memory.id);
+
+  await client.memories.createFile(memory.id, "/facts/product.md", {
+    content: "# Product\n\nEverruns runs autonomous agents.\n",
+    encoding: "text",
+  });
+
+  const results = await client.memories.grepFiles(memory.id, "agents");
+  console.log(`Found ${results.length} match(es) for 'agents'`);
+
+  const files = await client.memories.listFiles(memory.id);
+  console.log(`Memory has ${files.length} file(s)`);
+
+  await client.memories.delete(memory.id);
+  console.log("Archived memory");
+}
+
+main().catch(console.error);

--- a/typescript/examples/workspaces.ts
+++ b/typescript/examples/workspaces.ts
@@ -1,0 +1,42 @@
+/**
+ * Example: create a workspace and manage its files.
+ *
+ * Run with:
+ * `EVERRUNS_API_KEY=evr_... npx tsx examples/workspaces.ts`
+ */
+
+import { Everruns } from "../src/index.js";
+
+async function main() {
+  const client = Everruns.fromEnv();
+
+  const workspace = await client.workspaces.create({
+    name: "workspaces-example-ts",
+    description: "Shared files for the team",
+  });
+  console.log("Created workspace", workspace.id);
+
+  await client.workspaceFiles.create(
+    workspace.id,
+    "/notes/welcome.md",
+    "# Welcome\n\nShared workspace files live here.\n",
+    { encoding: "text" },
+  );
+
+  const file = await client.workspaceFiles.read(
+    workspace.id,
+    "/notes/welcome.md",
+  );
+  console.log(`Read ${file.path}:`);
+  console.log(file.content);
+
+  const files = await client.workspaceFiles.list(workspace.id, {
+    recursive: true,
+  });
+  console.log(`Workspace has ${files.data.length} file(s)`);
+
+  await client.workspaces.delete(workspace.id);
+  console.log("Archived workspace");
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

- Document the workspaces and memories surface adopted from upstream: runnable examples (`workspaces`/`memories`) for Rust, Python, and TypeScript, plus README and `docs/getting-started.md` sections and a cookbook table.
- Fix backslash-escaped code fences and underscores in the Rust and TypeScript READMEs that rendered literally on crates.io/npm.
- Wire the new examples into `check-examples-python` / `check-examples-typescript` so CI validates them (Rust is auto-covered via `cargo check --examples`).

## Test Plan

- `cargo check --examples` (Rust examples compile)
- `python -m py_compile` over all examples incl. new ones
- `tsc --noEmit` over all examples incl. new ones
- `cargo fmt --check`, `ruff check .` + `ruff format --check`, `oxlint src` all green
- Docs/examples-only change — no library source modified

- [x] Tests pass locally
- [ ] Coverage ≥80%
- [x] Linting passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [ ] Updated relevant specs (if applicable)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XnwVWAWPzixhpuzXxF5c65)_