### PR TITLE
docs(rust,python,typescript): fix invalid variable redeclaration in auth examples

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -75,8 +75,11 @@ The SDK uses personal access token authentication. Set `EVERRUNS_API_KEY` or pas
 ```python
 # From environment
 client = Everruns()
+```
 
-# Explicit token and organization
+Or with an explicit token and organization:
+
+```python
 client = Everruns(api_key="evr_pat_...", org_id="org_...")
 ```
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -139,8 +139,11 @@ The SDK uses personal access token authentication. Set the `EVERRUNS_API_KEY` en
 ```rust
 // From environment variable
 let client = Everruns::from_env()?;
+```
 
-// Explicit token and organization
+Or with an explicit token and organization:
+
+```rust
 let client = Everruns::builder()
     .api_key("evr_pat_...")
     .org_id("org_...")

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -121,8 +121,11 @@ The SDK uses personal access token authentication. Set the `EVERRUNS_API_KEY` en
 ```typescript
 // From environment variable
 const client = Everruns.fromEnv();
+```
 
-// Explicit token and organization
+Or with an explicit token and organization:
+
+```typescript
 const client = new Everruns({
 apiKey: "evr_pat_...",
 orgId: "org_..."


### PR DESCRIPTION
## Summary

- Split the Authentication examples (env-var vs explicit token) into separate code blocks so each is copy-paste valid.
- The TypeScript snippet redeclared `const client` in a single block, which is invalid TypeScript (flagged by Copilot on #93). Rust (`let` shadowing) and Python (reassignment) were legal but had the same confusing layout — apply the same two-block treatment for consistency.

## Test Plan

- Docs-only change; no code or tests affected.
- Verified each resulting snippet is self-contained and valid in its language.

- [x] Tests pass locally
- [ ] Coverage ≥80%
- [x] Linting passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [ ] Updated relevant specs (if applicable)
- [ ] Added/updated tests
- [x] Updated documentation (if applicable)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XnwVWAWPzixhpuzXxF5c65)_