### PR TITLE
chore(rust): add authors to crate metadata

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,6 +3,7 @@ name = "everruns-sdk"
 version = "0.1.9"
 edition = "2024"
 description = "Rust SDK for Everruns API"
+authors = ["Everruns <support@everruns.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/everruns/sdk"


### PR DESCRIPTION
## What

Add an `authors` field to the Rust SDK crate metadata (`rust/Cargo.toml`).

## Why

Metadata audit across all publishable targets found the Rust crate was missing `authors`, the only gap among the SDK targets. The Python SDK already declares the same author identity; this brings the Rust crate in line for consistent attribution on crates.io.

## How

- `authors = ["Everruns <support@everruns.com>"]`, matching `pyproject.toml`.

## Tests

- `cargo fmt --check` — clean
- `cargo test` — 17 unit + 2 doctests pass
- `cargo verify-project` — manifest valid


---
_Generated by [Claude Code](https://claude.ai/code/session_015TgRkfFz6qEhaiEH2WmbSP)_