### PR TITLE
chore(release): prepare v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.1.10] - 2026-06-19
+
+### Highlights
+
+- Workspaces and memories APIs across Rust, Python, and TypeScript SDKs
+- Agent behavioral health-check endpoints (list, trigger, get) across all SDKs
+- Agent analysis and guardrail helpers, plus session event-list filters
+- Refreshed generated schemas, dependency/security updates, and documentation
+
+### What's Changed
+
+* chore(rust): add authors to crate metadata ([#96](https://github.com/everruns/sdk/pull/96)) by @chaliy
+* ci: track everruns-server main HEAD again ([#95](https://github.com/everruns/sdk/pull/95)) by @chaliy
+* docs(rust,python,typescript): fix invalid variable redeclaration in auth examples ([#94](https://github.com/everruns/sdk/pull/94)) by @chaliy
+* docs(rust,python,typescript): document workspaces and memories APIs ([#93](https://github.com/everruns/sdk/pull/93)) by @chaliy
+* feat: adopt agent health-checks, refresh deps ([#92](https://github.com/everruns/sdk/pull/92)) by @chaliy
+* feat: adopt upstream workspace and memory APIs ([#91](https://github.com/everruns/sdk/pull/91)) by @chaliy
+* feat: adopt upstream API refresh ([#90](https://github.com/everruns/sdk/pull/90)) by @chaliy
+* fix(typescript): address code scanning alerts ([#89](https://github.com/everruns/sdk/pull/89)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/sdk/compare/v0.1.9...v0.1.10
+
 ## [0.1.9] - 2026-05-08
 
 ### Highlights

--- a/python/everruns_sdk/__init__.py
+++ b/python/everruns_sdk/__init__.py
@@ -160,4 +160,4 @@ __all__ = [
     "validate_harness_name",
 ]
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "everruns-sdk"
-version = "0.1.9"
+version = "0.1.10"
 description = "Python SDK for Everruns API"
 readme = "README.md"
 license = "MIT"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -172,7 +172,7 @@ toml = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-stream",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-sdk"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Rust SDK for Everruns API"
 authors = ["Everruns <support@everruns.com>"]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/sdk",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "TypeScript SDK for Everruns API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump Rust, Python, and TypeScript SDK package versions to `0.1.10` (manifests + lockfiles + Python `__version__`).
- Add the `0.1.10` CHANGELOG entry covering PRs #89–#96 (workspaces/memories APIs, agent health-checks, upstream API refresh, docs, CI, and metadata).

## Test Plan

- [x] Tests pass locally: `cargo test` (17 + 2 doctests), `uv run pytest` (153), `npm test` (143)
- [x] Coverage ≥80%: existing suite maintained; release-only change
- [x] Linting passes: `cargo fmt`/`clippy`, `ruff check`/`format`, `oxlint`
- [x] `publish-dry-run`: `cargo publish --dry-run`, `uv build`, `npm run build` all succeed
- [x] Pre-push attribution check passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable) — n/a, release-only
- [x] Added/updated tests — n/a, release-only
- [x] Updated documentation (CHANGELOG.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcfgrGzNWsK5pXBybqmwbL)_