### PR TITLE
fix(typescript): map snake_case responses onto camelCase models

### DIFF
--- a/scripts/sdk_codegen.py
+++ b/scripts/sdk_codegen.py
@@ -616,6 +616,131 @@ class TypeScriptEmitter(Emitter):
             return wire_name
         return camel_case(wire_name)
 
+    def object_models(self) -> list[tuple[Model, Mapping[str, Any]]]:
+        """Models emitted as `interface` (i.e. not enum / scalar alias / union)."""
+        result: list[tuple[Model, Mapping[str, Any]]] = []
+        for model in self.models:
+            schema = self.schema_for(model, flatten=model.name in self.flatten_models)
+            if schema.get("enum") and schema.get("type") == "string":
+                continue
+            if self.is_scalar_alias(schema):
+                continue
+            if "oneOf" in schema:
+                continue
+            result.append((model, schema))
+        return result
+
+    def field_model_ref(
+        self, field_schema: Mapping[str, Any], object_names: set[str]
+    ) -> str | None:
+        """Nested object-model a field decodes into (directly or per array item),
+        or None for scalars, enums, unions, and free-form maps."""
+        schema = without_null(field_schema)
+        ref = None
+        if "$ref" in schema:
+            ref = self.public_ref_name(str(schema["$ref"]))
+        elif schema.get("type") == "array":
+            item = without_null(schema.get("items", {}))
+            if "$ref" in item:
+                ref = self.public_ref_name(str(item["$ref"]))
+        return ref if ref in object_names else None
+
+    def wire_models(self) -> list[tuple[str, list[tuple[str, str, str | None]]]]:
+        """Per-model wire-decode descriptors: (model, [(wire, ts, nested_model)]).
+
+        Only fields whose wire key differs from the camelCase property, or that
+        decode into a nested model, are listed. Free-form `Record`/`unknown`
+        fields are omitted so their keys pass through untouched. Models with no
+        such fields are dropped entirely (the decoder treats a missing descriptor
+        as passthrough)."""
+        object_names = {model.name for model, _ in self.object_models()}
+        type_overrides = self.settings().get("typeOverrides", {})
+        result: list[tuple[str, list[tuple[str, str, str | None]]]] = []
+        for model, schema in self.object_models():
+            omitted = set(self.settings().get("omitFields", {}).get(model.name, []))
+            fields: list[tuple[str, str, str | None]] = []
+            for wire_name, field_schema in self.properties_for(model.name, schema):
+                if wire_name in omitted:
+                    continue
+                ts_name = self.field_name(model.name, wire_name)
+                ref = None
+                if f"{model.name}.{wire_name}" not in type_overrides:
+                    ref = self.field_model_ref(field_schema, object_names)
+                if ts_name == wire_name and ref is None:
+                    continue
+                fields.append((wire_name, ts_name, ref))
+            if fields:
+                result.append((model.name, fields))
+        return result
+
+    def emit_wire_models(self) -> list[str]:
+        lines = [
+            "/** Wire field descriptor: rename to `name`, decode into `model`. */",
+            "interface WireField {",
+            "  name: string;",
+            "  model?: string;",
+            "}",
+            "",
+            "/**",
+            " * Response decode map (generated). The API serializes responses in",
+            " * snake_case; these descriptors map each known model shape onto its",
+            " * camelCase properties. Free-form object fields (Record<string, unknown>,",
+            " * unknown) are deliberately absent so data-bearing keys pass through",
+            " * unchanged.",
+            " */",
+            "const WIRE_MODELS: Record<string, Record<string, WireField>> = {",
+        ]
+        for model_name, fields in self.wire_models():
+            lines.append(f"  {model_name}: {{")
+            for wire_name, ts_name, ref in fields:
+                value = f"{{ name: {json.dumps(ts_name)}"
+                if ref is not None:
+                    value += f", model: {json.dumps(ref)}"
+                value += " }"
+                lines.append(f"    {json.dumps(wire_name)}: {value},")
+            lines.append("  },")
+        lines.extend(
+            [
+                "};",
+                "",
+                "/**",
+                " * Decode a parsed JSON response into its typed model shape, mapping",
+                " * snake_case wire keys to camelCase properties. Arrays are decoded",
+                " * element-wise; unknown keys and free-form nested objects are left as-is.",
+                " */",
+                "export function decodeModel<T>(value: unknown, model: string): T {",
+                "  return decodeWire(value, model) as T;",
+                "}",
+                "",
+                "function decodeWire(value: unknown, model: string): unknown {",
+                "  if (Array.isArray(value)) {",
+                "    return value.map((item) => decodeWire(item, model));",
+                "  }",
+                '  if (value === null || typeof value !== "object") {',
+                "    return value;",
+                "  }",
+                "  const fields = WIRE_MODELS[model];",
+                "  if (fields === undefined) {",
+                "    return value;",
+                "  }",
+                "  const out: Record<string, unknown> = {};",
+                "  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {",
+                "    const spec = fields[key];",
+                "    if (spec === undefined) {",
+                "      out[key] = val;",
+                "    } else if (spec.model !== undefined) {",
+                "      out[spec.name] = decodeWire(val, spec.model);",
+                "    } else {",
+                "      out[spec.name] = val;",
+                "    }",
+                "  }",
+                "  return out;",
+                "}",
+                "",
+            ]
+        )
+        return lines
+
     def type_expr(self, schema: Mapping[str, Any]) -> str:
         nullable = is_nullable(schema)
         schema = without_null(schema)
@@ -782,6 +907,7 @@ class TypeScriptEmitter(Emitter):
                 "",
             ]
         )
+        lines.extend(self.emit_wire_models())
         return "\n".join(lines)
 
 

--- a/scripts/test_generate.py
+++ b/scripts/test_generate.py
@@ -87,6 +87,22 @@ class GenerateTests(unittest.TestCase):
         self.assertIn("displayName?: string | null;", output)
         self.assertNotIn("WithUrls_Agent", output)
 
+    def test_typescript_emits_wire_decode_map(self) -> None:
+        models = sdk_codegen.build_models(small_spec(), {"models": ["Agent"]})
+        output = sdk_codegen.TypeScriptEmitter(
+            models, small_spec()["components"]["schemas"], {}
+        ).emit()
+        # Multi-word wire keys map to their camelCase property. (Raw emit quotes
+        # the keys; prettier strips the quotes when the file is written out.)
+        self.assertIn('"display_name": { name: "displayName" }', output)
+        # A generic decoder is exported for the response path.
+        self.assertIn(
+            "export function decodeModel<T>(value: unknown, model: string): T",
+            output,
+        )
+        # Single-word keys need no entry (they pass through untouched).
+        self.assertNotIn('"id":', output)
+
     def test_generation_is_deterministic_and_targeted(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -58,6 +58,7 @@ import {
   UpdateMemoryRequest,
   UpdateWorkspaceRequest,
   Workspace,
+  decodeModel,
   validateAgentName,
   validateHarnessName,
 } from "./models.js";
@@ -150,7 +151,19 @@ export class Everruns {
     return `${this.baseUrl}/v1${normalizedPath}`;
   }
 
-  async fetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  /**
+   * Perform a JSON request.
+   *
+   * When `model` is given, the parsed body is run through {@link decodeModel}
+   * to map the API's snake_case wire fields onto the camelCase model shape.
+   * Free-form object fields are left untouched. Envelope responses (whose
+   * payload is nested under a key) decode the inner value at the call site.
+   */
+  async fetch<T>(
+    path: string,
+    options: RequestInit = {},
+    model?: string,
+  ): Promise<T> {
     const url = this.url(path);
     const response = await fetch(url, {
       ...options,
@@ -187,7 +200,8 @@ export class Everruns {
       return undefined as T;
     }
 
-    return response.json() as Promise<T>;
+    const data = await response.json();
+    return (model !== undefined ? decodeModel<T>(data, model) : data) as T;
   }
 
   async fetchText(path: string, options: RequestInit = {}): Promise<string> {
@@ -276,10 +290,11 @@ class AgentsClient {
   async create(request: CreateAgentRequest): Promise<Agent> {
     validateAgentName(request.name);
     validateAgentHarness(request);
-    return this.client.fetch("/agents", {
-      method: "POST",
-      body: JSON.stringify(toAgentBody(request)),
-    });
+    return this.client.fetch(
+      "/agents",
+      { method: "POST", body: JSON.stringify(toAgentBody(request)) },
+      "Agent",
+    );
   }
 
   /**
@@ -293,10 +308,11 @@ class AgentsClient {
   async apply(id: string, request: CreateAgentRequest): Promise<Agent> {
     validateAgentName(request.name);
     validateAgentHarness(request);
-    return this.client.fetch("/agents", {
-      method: "POST",
-      body: JSON.stringify({ ...toAgentBody(request), id }),
-    });
+    return this.client.fetch(
+      "/agents",
+      { method: "POST", body: JSON.stringify({ ...toAgentBody(request), id }) },
+      "Agent",
+    );
   }
 
   /**
@@ -308,31 +324,42 @@ class AgentsClient {
   async applyByName(request: CreateAgentRequest): Promise<Agent> {
     validateAgentName(request.name);
     validateAgentHarness(request);
-    return this.client.fetch("/agents", {
-      method: "POST",
-      body: JSON.stringify(toAgentBody(request)),
-    });
+    return this.client.fetch(
+      "/agents",
+      { method: "POST", body: JSON.stringify(toAgentBody(request)) },
+      "Agent",
+    );
   }
 
   async get(agentId: string): Promise<Agent> {
-    return this.client.fetch(`/agents/${agentId}`);
+    return this.client.fetch(`/agents/${agentId}`, undefined, "Agent");
   }
 
   /** Get aggregate usage stats for an agent. */
   async stats(agentId: string): Promise<ResourceStats> {
-    return this.client.fetch(`/agents/${agentId}/stats`);
+    return this.client.fetch(
+      `/agents/${agentId}/stats`,
+      undefined,
+      "ResourceStats",
+    );
   }
 
   /** List recent behavioral health check runs for an agent. */
   async listHealthChecks(agentId: string): Promise<HealthCheckRun[]> {
-    return this.client.fetch(`/agents/${agentId}/health-checks`);
+    return this.client.fetch(
+      `/agents/${agentId}/health-checks`,
+      undefined,
+      "HealthCheckRun",
+    );
   }
 
   /** Trigger a behavioral health check for an agent. */
   async triggerHealthCheck(agentId: string): Promise<HealthCheckRun> {
-    return this.client.fetch(`/agents/${agentId}/health-checks`, {
-      method: "POST",
-    });
+    return this.client.fetch(
+      `/agents/${agentId}/health-checks`,
+      { method: "POST" },
+      "HealthCheckRun",
+    );
   }
 
   /** Get a single health check run for an agent. */
@@ -340,12 +367,20 @@ class AgentsClient {
     agentId: string,
     runId: string,
   ): Promise<HealthCheckRun> {
-    return this.client.fetch(`/agents/${agentId}/health-checks/${runId}`);
+    return this.client.fetch(
+      `/agents/${agentId}/health-checks/${runId}`,
+      undefined,
+      "HealthCheckRun",
+    );
   }
 
   /** List saved versions for an agent. */
   async listVersions(agentId: string): Promise<AgentVersion[]> {
-    return this.client.fetch(`/agents/${agentId}/versions`);
+    return this.client.fetch(
+      `/agents/${agentId}/versions`,
+      undefined,
+      "AgentVersion",
+    );
   }
 
   /** Save the current agent configuration as a version. */
@@ -353,10 +388,14 @@ class AgentsClient {
     agentId: string,
     request: CreateAgentVersionRequest = {},
   ): Promise<AgentVersion> {
-    return this.client.fetch(`/agents/${agentId}/versions`, {
-      method: "POST",
-      body: JSON.stringify(toCreateAgentVersionBody(request)),
-    });
+    return this.client.fetch(
+      `/agents/${agentId}/versions`,
+      {
+        method: "POST",
+        body: JSON.stringify(toCreateAgentVersionBody(request)),
+      },
+      "AgentVersion",
+    );
   }
 
   /** Set the default version for an agent. */
@@ -364,10 +403,14 @@ class AgentsClient {
     agentId: string,
     request: SetDefaultAgentVersionRequest,
   ): Promise<Agent> {
-    return this.client.fetch(`/agents/${agentId}/versions/default`, {
-      method: "POST",
-      body: JSON.stringify({ version_id: request.versionId }),
-    });
+    return this.client.fetch(
+      `/agents/${agentId}/versions/default`,
+      {
+        method: "POST",
+        body: JSON.stringify({ version_id: request.versionId }),
+      },
+      "Agent",
+    );
   }
 
   /** Diff two saved agent versions. */
@@ -378,6 +421,8 @@ class AgentsClient {
   ): Promise<AgentVersionDiffResponse> {
     return this.client.fetch(
       `/agents/${agentId}/versions/${fromVersionId}/diff/${toVersionId}`,
+      undefined,
+      "AgentVersionDiffResponse",
     );
   }
 
@@ -388,10 +433,11 @@ class AgentsClient {
     request: ForkAgentVersionRequest,
   ): Promise<Agent> {
     validateAgentName(request.name);
-    return this.client.fetch(`/agents/${agentId}/versions/${versionId}/fork`, {
-      method: "POST",
-      body: JSON.stringify(toForkAgentVersionBody(request)),
-    });
+    return this.client.fetch(
+      `/agents/${agentId}/versions/${versionId}/fork`,
+      { method: "POST", body: JSON.stringify(toForkAgentVersionBody(request)) },
+      "Agent",
+    );
   }
 
   /** Restore an agent from a saved version. */
@@ -406,6 +452,7 @@ class AgentsClient {
         method: "POST",
         body: JSON.stringify(toRollbackAgentVersionBody(request)),
       },
+      "Agent",
     );
   }
 
@@ -416,12 +463,16 @@ class AgentsClient {
     const response = await this.client.fetch<{ agents: Agent[] }>(
       `/agents${query}`,
     );
-    return response.agents;
+    return decodeModel(response.agents, "Agent");
   }
 
   /** Copy an agent, creating a new agent with the same configuration. */
   async copy(agentId: string): Promise<Agent> {
-    return this.client.fetch(`/agents/${agentId}/copy`, { method: "POST" });
+    return this.client.fetch(
+      `/agents/${agentId}/copy`,
+      { method: "POST" },
+      "Agent",
+    );
   }
 
   async delete(agentId: string): Promise<void> {
@@ -430,22 +481,30 @@ class AgentsClient {
 
   /** Import an agent from Markdown, YAML, JSON, or plain text. */
   async import(content: string): Promise<Agent> {
-    return this.client.fetch("/agents/import", {
-      method: "POST",
-      body: content,
-      headers: { "Content-Type": "text/plain" },
-    });
+    return this.client.fetch(
+      "/agents/import",
+      {
+        method: "POST",
+        body: content,
+        headers: { "Content-Type": "text/plain" },
+      },
+      "Agent",
+    );
   }
 
   /** Import an agent from a built-in example. */
   async importExample(exampleName: string): Promise<Agent> {
     const params = new URLSearchParams();
     params.set("from-example", exampleName);
-    return this.client.fetch(`/agents/import?${params.toString()}`, {
-      method: "POST",
-      body: "",
-      headers: { "Content-Type": "text/plain" },
-    });
+    return this.client.fetch(
+      `/agents/import?${params.toString()}`,
+      {
+        method: "POST",
+        body: "",
+        headers: { "Content-Type": "text/plain" },
+      },
+      "Agent",
+    );
   }
 
   /** Export an agent as Markdown with YAML front matter. */
@@ -455,15 +514,19 @@ class AgentsClient {
 
   /** Run advisory checks against an agent shape. */
   async analyze(request: AnalyzeAgentRequest): Promise<AgentAnalysisResponse> {
-    return this.client.fetch("/agents/analyze", {
-      method: "POST",
-      body: JSON.stringify({
-        system_prompt: request.systemPrompt,
-        capabilities: request.capabilities ?? [],
-        tools: request.tools ?? [],
-        mcpServers: request.mcpServers,
-      }),
-    });
+    return this.client.fetch(
+      "/agents/analyze",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          system_prompt: request.systemPrompt,
+          capabilities: request.capabilities ?? [],
+          tools: request.tools ?? [],
+          mcpServers: request.mcpServers,
+        }),
+      },
+      "AgentAnalysisResponse",
+    );
   }
 }
 
@@ -525,14 +588,15 @@ class SessionsClient {
     if (request.parallelToolCalls !== undefined) {
       body.parallel_tool_calls = request.parallelToolCalls;
     }
-    return this.client.fetch("/sessions", {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
+    return this.client.fetch(
+      "/sessions",
+      { method: "POST", body: JSON.stringify(body) },
+      "Session",
+    );
   }
 
   async get(sessionId: string): Promise<Session> {
-    return this.client.fetch(`/sessions/${sessionId}`);
+    return this.client.fetch(`/sessions/${sessionId}`, undefined, "Session");
   }
 
   async list(options?: {
@@ -546,7 +610,7 @@ class SessionsClient {
     const response = await this.client.fetch<{ sessions: Session[] }>(
       `/sessions${query}`,
     );
-    return response.sessions;
+    return decodeModel(response.sessions, "Session");
   }
 
   /** Delete a session. */
@@ -577,19 +641,29 @@ class SessionsClient {
 
   /** List budgets for a session. */
   async budgets(sessionId: string): Promise<Budget[]> {
-    return this.client.fetch(`/sessions/${sessionId}/budgets`);
+    return this.client.fetch(
+      `/sessions/${sessionId}/budgets`,
+      undefined,
+      "Budget",
+    );
   }
 
   /** Check all budgets in hierarchy for a session. */
   async budgetCheck(sessionId: string): Promise<BudgetCheckResult> {
-    return this.client.fetch(`/sessions/${sessionId}/budget-check`);
+    return this.client.fetch(
+      `/sessions/${sessionId}/budget-check`,
+      undefined,
+      "BudgetCheckResult",
+    );
   }
 
   /** Resume paused budgets for a session. */
   async resume(sessionId: string): Promise<ResumeSessionResponse> {
-    return this.client.fetch(`/sessions/${sessionId}/resume`, {
-      method: "POST",
-    });
+    return this.client.fetch(
+      `/sessions/${sessionId}/resume`,
+      { method: "POST" },
+      "ResumeSessionResponse",
+    );
   }
 
   /** Batch-set encrypted secrets for a session. */
@@ -633,10 +707,11 @@ class MessagesClient {
             },
           }
         : textOrRequest;
-    return this.client.fetch(`/sessions/${sessionId}/messages`, {
-      method: "POST",
-      body: JSON.stringify(request),
-    });
+    return this.client.fetch(
+      `/sessions/${sessionId}/messages`,
+      { method: "POST", body: JSON.stringify(request) },
+      "Message",
+    );
   }
 
   /**
@@ -665,10 +740,11 @@ class MessagesClient {
     let delay = 100;
     for (let attempt = 0; attempt <= 5; attempt++) {
       try {
-        return await this.client.fetch(`/sessions/${sessionId}/tool-results`, {
-          method: "POST",
-          body,
-        });
+        return await this.client.fetch(
+          `/sessions/${sessionId}/tool-results`,
+          { method: "POST", body },
+          "SubmitToolResultsResponse",
+        );
       } catch (error) {
         if (attempt >= 5 || !isToolResultsPendingConflict(error)) {
           throw error;
@@ -684,7 +760,7 @@ class MessagesClient {
     const response = await this.client.fetch<{ messages: Message[] }>(
       `/sessions/${sessionId}/messages`,
     );
-    return response.messages;
+    return decodeModel(response.messages, "Message");
   }
 }
 
@@ -741,7 +817,7 @@ class EventsClient {
     const response = await this.client.fetch<ListResponse<Event>>(
       `/sessions/${sessionId}/events${query}`,
     );
-    return response.data;
+    return decodeModel(response.data, "Event");
   }
 
   /**
@@ -794,7 +870,7 @@ class CapabilitiesClient {
       `/capabilities${query}`,
     );
     return {
-      data: response.data,
+      data: decodeModel(response.data, "CapabilityInfo"),
       total: response.total ?? 0,
       offset: response.offset ?? 0,
       limit: response.limit ?? 0,
@@ -803,27 +879,39 @@ class CapabilitiesClient {
 
   /** Get a specific capability by ID. */
   async get(capabilityId: string): Promise<CapabilityInfo> {
-    return this.client.fetch(`/capabilities/${capabilityId}`);
+    return this.client.fetch(
+      `/capabilities/${capabilityId}`,
+      undefined,
+      "CapabilityInfo",
+    );
   }
 
   /** List adoptable guardrail presets. */
   async listGuardrailExamples(): Promise<GuardrailExamplesResponse> {
-    return this.client.fetch("/capabilities/guardrails/examples");
+    return this.client.fetch(
+      "/capabilities/guardrails/examples",
+      undefined,
+      "GuardrailExamplesResponse",
+    );
   }
 
   /** Evaluate a guardrails config against sample content. */
   async dryRunGuardrails(
     request: GuardrailsDryRunRequest,
   ): Promise<GuardrailsDryRunResponse> {
-    return this.client.fetch("/capabilities/guardrails/dry-run", {
-      method: "POST",
-      body: JSON.stringify({
-        config: request.config,
-        stage: request.stage,
-        text: request.text,
-        tool_name: request.toolName,
-      }),
-    });
+    return this.client.fetch(
+      "/capabilities/guardrails/dry-run",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          config: request.config,
+          stage: request.stage,
+          text: request.text,
+          tool_name: request.toolName,
+        }),
+      },
+      "GuardrailsDryRunResponse",
+    );
   }
 }
 
@@ -832,34 +920,41 @@ class HarnessesClient {
 
   /** List harnesses. */
   async list(): Promise<ListResponse<Harness>> {
-    return this.client.fetch("/harnesses");
+    const response =
+      await this.client.fetch<ListResponse<Harness>>("/harnesses");
+    return { ...response, data: decodeModel(response.data, "Harness") };
   }
 
   /** Search harnesses by query. */
   async search(query: string): Promise<ListResponse<Harness>> {
-    return this.client.fetch(`/harnesses?search=${encodeURIComponent(query)}`);
+    const response = await this.client.fetch<ListResponse<Harness>>(
+      `/harnesses?search=${encodeURIComponent(query)}`,
+    );
+    return { ...response, data: decodeModel(response.data, "Harness") };
   }
 
   /** Get a harness by ID. */
   async get(id: string): Promise<Harness> {
-    return this.client.fetch(`/harnesses/${id}`);
+    return this.client.fetch(`/harnesses/${id}`, undefined, "Harness");
   }
 
   /** Create a new harness. */
   async create(request: CreateHarnessRequest): Promise<Harness> {
     validateHarnessName(request.name);
-    return this.client.fetch("/harnesses", {
-      method: "POST",
-      body: JSON.stringify(toHarnessBody(request)),
-    });
+    return this.client.fetch(
+      "/harnesses",
+      { method: "POST", body: JSON.stringify(toHarnessBody(request)) },
+      "Harness",
+    );
   }
 
   /** Update a harness. Only provided fields are updated. */
   async update(id: string, request: UpdateHarnessRequest): Promise<Harness> {
-    return this.client.fetch(`/harnesses/${id}`, {
-      method: "PATCH",
-      body: JSON.stringify(toHarnessBody(request)),
-    });
+    return this.client.fetch(
+      `/harnesses/${id}`,
+      { method: "PATCH", body: JSON.stringify(toHarnessBody(request)) },
+      "Harness",
+    );
   }
 
   /** Delete a harness. */
@@ -869,7 +964,7 @@ class HarnessesClient {
 
   /** List built-in harness examples. */
   async listExamples(): Promise<HarnessExample[]> {
-    return this.client.fetch("/harness-examples");
+    return this.client.fetch("/harness-examples", undefined, "HarnessExample");
   }
 }
 
@@ -878,12 +973,17 @@ class ModelsClient {
 
   /** List available models. */
   async list(): Promise<ListResponse<ModelWithProvider>> {
-    return this.client.fetch("/models");
+    const response =
+      await this.client.fetch<ListResponse<ModelWithProvider>>("/models");
+    return {
+      ...response,
+      data: decodeModel(response.data, "ModelWithProvider"),
+    };
   }
 
   /** Get a specific model by ID. */
   async get(id: string): Promise<ModelWithProvider> {
-    return this.client.fetch(`/models/${id}`);
+    return this.client.fetch(`/models/${id}`, undefined, "ModelWithProvider");
   }
 }
 
@@ -904,20 +1004,25 @@ class WorkspacesClient {
     const response = await this.client.fetch<ListResponse<Workspace>>(
       `/workspaces${query}`,
     );
-    return response.data;
+    return decodeModel(response.data, "Workspace");
   }
 
   /** Create a workspace. */
   async create(request: CreateWorkspaceRequest): Promise<Workspace> {
-    return this.client.fetch("/workspaces", {
-      method: "POST",
-      body: JSON.stringify(request),
-    });
+    return this.client.fetch(
+      "/workspaces",
+      { method: "POST", body: JSON.stringify(request) },
+      "Workspace",
+    );
   }
 
   /** Get a workspace by ID. */
   async get(workspaceId: string): Promise<Workspace> {
-    return this.client.fetch(`/workspaces/${workspaceId}`);
+    return this.client.fetch(
+      `/workspaces/${workspaceId}`,
+      undefined,
+      "Workspace",
+    );
   }
 
   /** Update a workspace. */
@@ -925,10 +1030,11 @@ class WorkspacesClient {
     workspaceId: string,
     request: UpdateWorkspaceRequest,
   ): Promise<Workspace> {
-    return this.client.fetch(`/workspaces/${workspaceId}`, {
-      method: "PATCH",
-      body: JSON.stringify(request),
-    });
+    return this.client.fetch(
+      `/workspaces/${workspaceId}`,
+      { method: "PATCH", body: JSON.stringify(request) },
+      "Workspace",
+    );
   }
 
   /** Archive a workspace. */
@@ -955,7 +1061,7 @@ class WorkspaceFilesClient {
       `${fsPath}${query}`,
     );
     return {
-      data: response.data,
+      data: decodeModel(response.data, "FileInfo"),
       total: response.total ?? 0,
       offset: response.offset ?? 0,
       limit: response.limit ?? 0,
@@ -966,6 +1072,8 @@ class WorkspaceFilesClient {
   async read(workspaceId: string, path: string): Promise<SessionFile> {
     return this.client.fetch(
       `/workspaces/${workspaceId}/fs/${path.replace(/^\//, "")}`,
+      undefined,
+      "SessionFile",
     );
   }
 
@@ -982,6 +1090,7 @@ class WorkspaceFilesClient {
     return this.client.fetch(
       `/workspaces/${workspaceId}/fs/${path.replace(/^\//, "")}`,
       { method: "POST", body: JSON.stringify(body) },
+      "SessionFile",
     );
   }
 
@@ -990,6 +1099,7 @@ class WorkspaceFilesClient {
     return this.client.fetch(
       `/workspaces/${workspaceId}/fs/${path.replace(/^\//, "")}`,
       { method: "POST", body: JSON.stringify({ is_directory: true }) },
+      "SessionFile",
     );
   }
 
@@ -1006,6 +1116,7 @@ class WorkspaceFilesClient {
     return this.client.fetch(
       `/workspaces/${workspaceId}/fs/${path.replace(/^\//, "")}`,
       { method: "PUT", body: JSON.stringify(body) },
+      "SessionFile",
     );
   }
 
@@ -1021,6 +1132,7 @@ class WorkspaceFilesClient {
     return this.client.fetch(
       `/workspaces/${workspaceId}/fs/${path.replace(/^\//, "")}${query}`,
       { method: "DELETE" },
+      "DeleteFileResponse",
     );
   }
 
@@ -1030,10 +1142,14 @@ class WorkspaceFilesClient {
     srcPath: string,
     dstPath: string,
   ): Promise<SessionFile> {
-    return this.client.fetch(`/workspaces/${workspaceId}/fs/_/move`, {
-      method: "POST",
-      body: JSON.stringify({ src_path: srcPath, dst_path: dstPath }),
-    });
+    return this.client.fetch(
+      `/workspaces/${workspaceId}/fs/_/move`,
+      {
+        method: "POST",
+        body: JSON.stringify({ src_path: srcPath, dst_path: dstPath }),
+      },
+      "SessionFile",
+    );
   }
 
   /** Copy a file. */
@@ -1042,10 +1158,14 @@ class WorkspaceFilesClient {
     srcPath: string,
     dstPath: string,
   ): Promise<SessionFile> {
-    return this.client.fetch(`/workspaces/${workspaceId}/fs/_/copy`, {
-      method: "POST",
-      body: JSON.stringify({ src_path: srcPath, dst_path: dstPath }),
-    });
+    return this.client.fetch(
+      `/workspaces/${workspaceId}/fs/_/copy`,
+      {
+        method: "POST",
+        body: JSON.stringify({ src_path: srcPath, dst_path: dstPath }),
+      },
+      "SessionFile",
+    );
   }
 
   /** Search files with regex. */
@@ -1060,15 +1180,16 @@ class WorkspaceFilesClient {
       `/workspaces/${workspaceId}/fs/_/grep`,
       { method: "POST", body: JSON.stringify(body) },
     );
-    return response.data;
+    return decodeModel(response.data, "GrepResult");
   }
 
   /** Get file or directory stat. */
   async stat(workspaceId: string, path: string): Promise<FileStat> {
-    return this.client.fetch(`/workspaces/${workspaceId}/fs/_/stat`, {
-      method: "POST",
-      body: JSON.stringify({ path }),
-    });
+    return this.client.fetch(
+      `/workspaces/${workspaceId}/fs/_/stat`,
+      { method: "POST", body: JSON.stringify({ path }) },
+      "FileStat",
+    );
   }
 }
 
@@ -1089,20 +1210,21 @@ class MemoriesClient {
     const response = await this.client.fetch<ListResponse<Memory>>(
       `/memories${query}`,
     );
-    return response.data;
+    return decodeModel(response.data, "Memory");
   }
 
   /** Create a memory. */
   async create(request: CreateMemoryRequest): Promise<Memory> {
-    return this.client.fetch("/memories", {
-      method: "POST",
-      body: JSON.stringify(request),
-    });
+    return this.client.fetch(
+      "/memories",
+      { method: "POST", body: JSON.stringify(request) },
+      "Memory",
+    );
   }
 
   /** Get a memory by ID. */
   async get(memoryId: string): Promise<Memory> {
-    return this.client.fetch(`/memories/${memoryId}`);
+    return this.client.fetch(`/memories/${memoryId}`, undefined, "Memory");
   }
 
   /** Update a memory. */
@@ -1110,10 +1232,11 @@ class MemoriesClient {
     memoryId: string,
     request: UpdateMemoryRequest,
   ): Promise<Memory> {
-    return this.client.fetch(`/memories/${memoryId}`, {
-      method: "PATCH",
-      body: JSON.stringify(request),
-    });
+    return this.client.fetch(
+      `/memories/${memoryId}`,
+      { method: "PATCH", body: JSON.stringify(request) },
+      "Memory",
+    );
   }
 
   /** Archive a memory. */
@@ -1123,9 +1246,11 @@ class MemoriesClient {
 
   /** Trigger memory sync now. */
   async sync(memoryId: string): Promise<Memory> {
-    return this.client.fetch(`/memories/${memoryId}/sync`, {
-      method: "POST",
-    });
+    return this.client.fetch(
+      `/memories/${memoryId}/sync`,
+      { method: "POST" },
+      "Memory",
+    );
   }
 
   /** List memory files at the root. */
@@ -1133,13 +1258,15 @@ class MemoriesClient {
     const response = await this.client.fetch<ListResponse<MemoryFileInfo>>(
       `/memories/${memoryId}/fs`,
     );
-    return response.data;
+    return decodeModel(response.data, "MemoryFileInfo");
   }
 
   /** Read a memory file. */
   async readFile(memoryId: string, path: string): Promise<MemoryFile> {
     return this.client.fetch(
       `/memories/${memoryId}/fs/${path.replace(/^\//, "")}`,
+      undefined,
+      "MemoryFile",
     );
   }
 
@@ -1166,6 +1293,7 @@ class MemoriesClient {
           is_directory: request.isDirectory,
         }),
       },
+      "MemoryFileInfo",
     );
   }
 
@@ -1189,6 +1317,7 @@ class MemoriesClient {
           encoding: request.encoding,
         }),
       },
+      "MemoryFile",
     );
   }
 
@@ -1212,15 +1341,16 @@ class MemoriesClient {
       `/memories/${memoryId}/fs/_/grep`,
       { method: "POST", body: JSON.stringify(body) },
     );
-    return response.data;
+    return decodeModel(response.data, "MemoryGrepResult");
   }
 
   /** Stat a memory file or directory. */
   async statFile(memoryId: string, path: string): Promise<MemoryFileInfo> {
-    return this.client.fetch(`/memories/${memoryId}/fs/_/stat`, {
-      method: "POST",
-      body: JSON.stringify({ path }),
-    });
+    return this.client.fetch(
+      `/memories/${memoryId}/fs/_/stat`,
+      { method: "POST", body: JSON.stringify({ path }) },
+      "MemoryFileInfo",
+    );
   }
 }
 
@@ -1229,18 +1359,22 @@ class BudgetsClient {
 
   /** Create a budget. */
   async create(request: CreateBudgetRequest): Promise<Budget> {
-    return this.client.fetch("/budgets", {
-      method: "POST",
-      body: JSON.stringify({
-        subject_type: request.subjectType,
-        subject_id: request.subjectId,
-        currency: request.currency,
-        limit: request.limit,
-        soft_limit: request.softLimit,
-        period: request.period,
-        metadata: request.metadata,
-      }),
-    });
+    return this.client.fetch(
+      "/budgets",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          subject_type: request.subjectType,
+          subject_id: request.subjectId,
+          currency: request.currency,
+          limit: request.limit,
+          soft_limit: request.softLimit,
+          period: request.period,
+          metadata: request.metadata,
+        }),
+      },
+      "Budget",
+    );
   }
 
   /** List budgets, optionally filtered by subject. */
@@ -1252,12 +1386,12 @@ class BudgetsClient {
     if (options?.subjectType) params.set("subject_type", options.subjectType);
     if (options?.subjectId) params.set("subject_id", options.subjectId);
     const query = params.toString() ? `?${params}` : "";
-    return this.client.fetch(`/budgets${query}`);
+    return this.client.fetch(`/budgets${query}`, undefined, "Budget");
   }
 
   /** Get a budget by ID. */
   async get(budgetId: string): Promise<Budget> {
-    return this.client.fetch(`/budgets/${budgetId}`);
+    return this.client.fetch(`/budgets/${budgetId}`, undefined, "Budget");
   }
 
   /** Update a budget. */
@@ -1265,15 +1399,19 @@ class BudgetsClient {
     budgetId: string,
     request: UpdateBudgetRequest,
   ): Promise<Budget> {
-    return this.client.fetch(`/budgets/${budgetId}`, {
-      method: "PATCH",
-      body: JSON.stringify({
-        limit: request.limit,
-        soft_limit: request.softLimit,
-        status: request.status,
-        metadata: request.metadata,
-      }),
-    });
+    return this.client.fetch(
+      `/budgets/${budgetId}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          limit: request.limit,
+          soft_limit: request.softLimit,
+          status: request.status,
+          metadata: request.metadata,
+        }),
+      },
+      "Budget",
+    );
   }
 
   /** Delete (soft-delete) a budget. */
@@ -1283,10 +1421,11 @@ class BudgetsClient {
 
   /** Add credits to a budget. */
   async topUp(budgetId: string, request: TopUpRequest): Promise<Budget> {
-    return this.client.fetch(`/budgets/${budgetId}/top-up`, {
-      method: "POST",
-      body: JSON.stringify(request),
-    });
+    return this.client.fetch(
+      `/budgets/${budgetId}/top-up`,
+      { method: "POST", body: JSON.stringify(request) },
+      "Budget",
+    );
   }
 
   /** Get paginated ledger entries for a budget. */
@@ -1298,12 +1437,20 @@ class BudgetsClient {
     if (options?.limit != null) params.set("limit", String(options.limit));
     if (options?.offset != null) params.set("offset", String(options.offset));
     const query = params.toString() ? `?${params}` : "";
-    return this.client.fetch(`/budgets/${budgetId}/ledger${query}`);
+    return this.client.fetch(
+      `/budgets/${budgetId}/ledger${query}`,
+      undefined,
+      "LedgerEntry",
+    );
   }
 
   /** Check budget status. */
   async check(budgetId: string): Promise<BudgetCheckResult> {
-    return this.client.fetch(`/budgets/${budgetId}/check`);
+    return this.client.fetch(
+      `/budgets/${budgetId}/check`,
+      undefined,
+      "BudgetCheckResult",
+    );
   }
 }
 
@@ -1312,10 +1459,11 @@ class ConnectionsClient {
 
   /** Set an API key connection for a provider. */
   async set(provider: string, apiKey: string): Promise<Connection> {
-    return this.client.fetch(`/user/connections/${provider}`, {
-      method: "POST",
-      body: JSON.stringify({ api_key: apiKey }),
-    });
+    return this.client.fetch(
+      `/user/connections/${provider}`,
+      { method: "POST", body: JSON.stringify({ api_key: apiKey }) },
+      "Connection",
+    );
   }
 
   /** List all connections. */
@@ -1323,7 +1471,7 @@ class ConnectionsClient {
     const response = await this.client.fetch<{ data: Connection[] }>(
       "/user/connections",
     );
-    return response.data;
+    return decodeModel(response.data, "Connection");
   }
 
   /** Remove a connection. */

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -1085,3 +1085,387 @@ export function extractToolCalls(
     ];
   });
 }
+
+/** Wire field descriptor: rename to `name`, decode into `model`. */
+interface WireField {
+  name: string;
+  model?: string;
+}
+
+/**
+ * Response decode map (generated). The API serializes responses in
+ * snake_case; these descriptors map each known model shape onto its
+ * camelCase properties. Free-form object fields (Record<string, unknown>,
+ * unknown) are deliberately absent so data-bearing keys pass through
+ * unchanged.
+ */
+const WIRE_MODELS: Record<string, Record<string, WireField>> = {
+  Agent: {
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    created_at: { name: "createdAt" },
+    default_model_id: { name: "model" },
+    display_name: { name: "displayName" },
+    harness_id: { name: "harnessId" },
+    initial_files: { name: "initialFiles", model: "InitialFile" },
+    parallel_tool_calls: { name: "parallelToolCalls" },
+    system_prompt: { name: "systemPrompt" },
+    updated_at: { name: "updatedAt" },
+  },
+  AgentAnalysisResponse: {
+    findings: { name: "findings", model: "Finding" },
+  },
+  Budget: {
+    created_at: { name: "createdAt" },
+    organization_id: { name: "organizationId" },
+    period: { name: "period", model: "BudgetPeriod" },
+    period_started_at: { name: "periodStartedAt" },
+    soft_limit: { name: "softLimit" },
+    subject_id: { name: "subjectId" },
+    subject_type: { name: "subjectType" },
+    updated_at: { name: "updatedAt" },
+  },
+  BudgetCheckResult: {
+    budget_id: { name: "budgetId" },
+    error_code: { name: "errorCode" },
+    error_fields: { name: "errorFields" },
+  },
+  CapabilityInfo: {
+    agent_count: { name: "agentCount" },
+    config_schema: { name: "configSchema" },
+    config_ui_schema: { name: "configUiSchema" },
+    docs_slug: { name: "docsSlug" },
+    harness_count: { name: "harnessCount" },
+    is_guardrail: { name: "isGuardrail" },
+    is_mcp: { name: "isMcp" },
+    is_skill: { name: "isSkill" },
+    risk_level: { name: "riskLevel" },
+    system_prompt: { name: "systemPrompt" },
+    tool_definitions: { name: "toolDefinitions" },
+  },
+  Connection: {
+    created_at: { name: "createdAt" },
+    updated_at: { name: "updatedAt" },
+  },
+  Controls: {
+    error_disclosure: { name: "errorDisclosure" },
+    model_id: { name: "modelId" },
+  },
+  CopyFileRequest: {
+    dst_path: { name: "dstPath" },
+    src_path: { name: "srcPath" },
+  },
+  CostTier: {
+    above_tokens: { name: "aboveTokens" },
+    cache_read: { name: "cacheRead" },
+  },
+  CreateAgentRequest: {
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    default_model_id: { name: "model" },
+    display_name: { name: "displayName" },
+    harness_id: { name: "harnessId" },
+    harness_name: { name: "harnessName" },
+    initial_files: { name: "initialFiles", model: "InitialFile" },
+    max_iterations: { name: "maxIterations" },
+    network_access: { name: "networkAccess", model: "NetworkAccessList" },
+    parallel_tool_calls: { name: "parallelToolCalls" },
+    system_prompt: { name: "systemPrompt" },
+  },
+  CreateAgentVersionRequest: {
+    change_kind: { name: "changeKind" },
+  },
+  CreateBudgetRequest: {
+    period: { name: "period", model: "BudgetPeriod" },
+    soft_limit: { name: "softLimit" },
+    subject_id: { name: "subjectId" },
+    subject_type: { name: "subjectType" },
+  },
+  CreateFileRequest: {
+    is_directory: { name: "isDirectory" },
+    is_readonly: { name: "isReadonly" },
+  },
+  CreateHarnessRequest: {
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    default_model_id: { name: "defaultModelId" },
+    display_name: { name: "displayName" },
+    embedder_metadata: { name: "embedderMetadata" },
+    initial_files: { name: "initialFiles", model: "InitialFile" },
+    network_access: { name: "networkAccess", model: "NetworkAccessList" },
+    parent_harness_id: { name: "parentHarnessId" },
+    system_prompt: { name: "systemPrompt" },
+  },
+  CreateMemoryFileRequest: {
+    is_directory: { name: "isDirectory" },
+  },
+  CreateMessageRequest: {
+    addressed_participant_id: { name: "addressedParticipantId" },
+    controls: { name: "controls", model: "Controls" },
+    external_actor: { name: "externalActor", model: "ExternalActor" },
+    message: { name: "message", model: "MessageInput" },
+  },
+  CreateSessionRequest: {
+    agent_id: { name: "agentId" },
+    agent_identity_id: { name: "agentIdentityId" },
+    agent_name: { name: "agentName" },
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    harness_id: { name: "harnessId" },
+    harness_name: { name: "harnessName" },
+    initial_files: { name: "initialFiles", model: "InitialFile" },
+    max_iterations: { name: "maxIterations" },
+    model_id: { name: "modelId" },
+    network_access: { name: "networkAccess", model: "NetworkAccessList" },
+    parallel_tool_calls: { name: "parallelToolCalls" },
+    system_prompt: { name: "systemPrompt" },
+    workspace_id: { name: "workspaceId" },
+  },
+  Event: {
+    ts: { name: "createdAt" },
+  },
+  EventContext: {
+    exec_id: { name: "execId" },
+    input_message_id: { name: "inputMessageId" },
+    parent_span_id: { name: "parentSpanId" },
+    span_id: { name: "spanId" },
+    trace_id: { name: "traceId" },
+    turn_id: { name: "turnId" },
+  },
+  ExternalActor: {
+    actor_id: { name: "actorId" },
+    actor_name: { name: "actorName" },
+  },
+  Finding: {
+    location: { name: "location", model: "FindingLocation" },
+  },
+  ForkAgentVersionRequest: {
+    display_name: { name: "displayName" },
+  },
+  GrepRequest: {
+    path_pattern: { name: "pathPattern" },
+  },
+  GrepResult: {
+    matches: { name: "matches", model: "GrepMatch" },
+  },
+  GuardrailExamplesResponse: {
+    examples: { name: "examples", model: "GuardrailExample" },
+  },
+  GuardrailsDryRunRequest: {
+    tool_name: { name: "toolName" },
+  },
+  GuardrailsDryRunResponse: {
+    hits: { name: "hits", model: "GuardrailsDryRunHit" },
+  },
+  Harness: {
+    archived_at: { name: "archivedAt" },
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    created_at: { name: "createdAt" },
+    default_model_id: { name: "defaultModelId" },
+    deleted_at: { name: "deletedAt" },
+    display_name: { name: "displayName" },
+    embedder_metadata: { name: "embedderMetadata" },
+    initial_files: { name: "initialFiles", model: "InitialFile" },
+    is_built_in: { name: "isBuiltIn" },
+    network_access: { name: "networkAccess", model: "NetworkAccessList" },
+    parallel_tool_calls: { name: "parallelToolCalls" },
+    parent_harness_id: { name: "parentHarnessId" },
+    system_prompt: { name: "systemPrompt" },
+    updated_at: { name: "updatedAt" },
+  },
+  HarnessExample: {
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    dev_only: { name: "devOnly" },
+    display_name: { name: "displayName" },
+    parent_name: { name: "parentName" },
+  },
+  HealthCheckRun: {
+    results: { name: "results", model: "HealthCheckCaseResult" },
+    summary: { name: "summary", model: "HealthCheckSummary" },
+  },
+  InitialFile: {
+    is_readonly: { name: "isReadonly" },
+  },
+  LedgerEntry: {
+    budget_id: { name: "budgetId" },
+    created_at: { name: "createdAt" },
+    meter_source: { name: "meterSource" },
+    ref_id: { name: "refId" },
+    ref_type: { name: "refType" },
+    session_id: { name: "sessionId" },
+  },
+  Message: {
+    content: { name: "content", model: "ContentPart" },
+    controls: { name: "controls", model: "Controls" },
+    created_at: { name: "createdAt" },
+    external_actor: { name: "externalActor", model: "ExternalActor" },
+    thinking_signature: { name: "thinkingSignature" },
+  },
+  ModelCost: {
+    cache_read: { name: "cacheRead" },
+    cost_tiers: { name: "costTiers", model: "CostTier" },
+  },
+  ModelLimits: {
+    max_media: { name: "maxMedia" },
+  },
+  ModelProfile: {
+    cost: { name: "cost", model: "ModelCost" },
+    last_updated: { name: "lastUpdated" },
+    limits: { name: "limits", model: "ModelLimits" },
+    modalities: { name: "modalities", model: "ModelModalities" },
+    open_weights: { name: "openWeights" },
+    reasoning_effort: {
+      name: "reasoningEffort",
+      model: "ReasoningEffortConfig",
+    },
+    release_date: { name: "releaseDate" },
+    structured_output: { name: "structuredOutput" },
+    supported_parameters: { name: "supportedParameters" },
+    supports_phases: { name: "supportsPhases" },
+    tool_call: { name: "toolCall" },
+    tool_search: { name: "toolSearch" },
+  },
+  ModelWithProvider: {
+    created_at: { name: "createdAt" },
+    display_name: { name: "displayName" },
+    is_favorite: { name: "isFavorite" },
+    model_id: { name: "modelId" },
+    model_vendor: { name: "modelVendor" },
+    profile: { name: "profile", model: "ModelProfile" },
+    provider_id: { name: "providerId" },
+    provider_name: { name: "providerName" },
+    provider_type: { name: "providerType" },
+    updated_at: { name: "updatedAt" },
+  },
+  MoveFileRequest: {
+    dst_path: { name: "dstPath" },
+    src_path: { name: "srcPath" },
+  },
+  ReasoningEffortConfig: {
+    values: { name: "values", model: "ReasoningEffortValue" },
+  },
+  ResumeSessionResponse: {
+    resumed_budgets: { name: "resumedBudgets" },
+    session_id: { name: "sessionId" },
+  },
+  RollbackAgentVersionRequest: {
+    save_version: { name: "saveVersion" },
+  },
+  Session: {
+    active_schedule_count: { name: "activeScheduleCount" },
+    agent_id: { name: "agentId" },
+    agent_identity_id: { name: "agentIdentityId" },
+    agent_version_id: { name: "agentVersionId" },
+    blueprint_config: { name: "blueprintConfig" },
+    blueprint_id: { name: "blueprintId" },
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    created_at: { name: "createdAt" },
+    effective_owner: { name: "effectiveOwner" },
+    finished_at: { name: "finishedAt" },
+    forked_from_sequence: { name: "forkedFromSequence" },
+    forked_from_session_id: { name: "forkedFromSessionId" },
+    harness_id: { name: "harnessId" },
+    initial_files: { name: "initialFiles", model: "InitialFile" },
+    is_pinned: { name: "isPinned" },
+    max_iterations: { name: "maxIterations" },
+    model_id: { name: "modelId" },
+    network_access: { name: "networkAccess", model: "NetworkAccessList" },
+    output_preview: { name: "outputPreview" },
+    owner_principal_id: { name: "ownerPrincipalId" },
+    parallel_tool_calls: { name: "parallelToolCalls" },
+    parent_session_id: { name: "parentSessionId" },
+    resolved_owner_user_id: { name: "resolvedOwnerUserId" },
+    started_at: { name: "startedAt" },
+    system_prompt: { name: "systemPrompt" },
+    updated_at: { name: "updatedAt" },
+    workspace_id: { name: "workspaceId" },
+  },
+  SetDefaultAgentVersionRequest: {
+    version_id: { name: "versionId" },
+  },
+  SubmitToolResultsRequest: {
+    tool_results: { name: "toolResults", model: "ClientToolResult" },
+  },
+  TokenUsage: {
+    actual_cost_usd: { name: "actualCostUsd" },
+    cache_creation_tokens: { name: "cacheCreationTokens" },
+    cache_read_tokens: { name: "cacheReadTokens" },
+    effective_cost_usd: { name: "effectiveCostUsd" },
+    estimated_cost_usd: { name: "estimatedCostUsd" },
+    input_tokens: { name: "inputTokens" },
+    output_tokens: { name: "outputTokens" },
+  },
+  UpdateBudgetRequest: {
+    soft_limit: { name: "softLimit" },
+  },
+  UpdateFileRequest: {
+    is_readonly: { name: "isReadonly" },
+  },
+  UpdateHarnessRequest: {
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    default_model_id: { name: "defaultModelId" },
+    display_name: { name: "displayName" },
+    embedder_metadata: { name: "embedderMetadata" },
+    initial_files: { name: "initialFiles", model: "InitialFile" },
+    network_access: { name: "networkAccess", model: "NetworkAccessList" },
+    parent_harness_id: { name: "parentHarnessId" },
+    system_prompt: { name: "systemPrompt" },
+  },
+  AnalyzeAgentRequest: {
+    capabilities: { name: "capabilities", model: "AgentCapabilityConfig" },
+    system_prompt: { name: "systemPrompt" },
+  },
+  ListEventsOptions: {
+    since_id: { name: "sinceId" },
+    before_sequence: { name: "beforeSequence" },
+    after_sequence: { name: "afterSequence" },
+    from_ts: { name: "fromTs" },
+    to_ts: { name: "toTs" },
+    turn_id: { name: "turnId" },
+    exec_id: { name: "execId" },
+    trace_id: { name: "traceId" },
+    tool_name: { name: "toolName" },
+    order_desc: { name: "orderDesc" },
+  },
+  MessageInput: {
+    content: { name: "content", model: "ContentPart" },
+  },
+  SetConnectionRequest: {
+    api_key: { name: "apiKey" },
+  },
+  StreamOptions: {
+    since_id: { name: "sinceId" },
+    max_retries: { name: "maxRetries" },
+    idle_timeout_ms: { name: "idleTimeoutMs" },
+  },
+};
+
+/**
+ * Decode a parsed JSON response into its typed model shape, mapping
+ * snake_case wire keys to camelCase properties. Arrays are decoded
+ * element-wise; unknown keys and free-form nested objects are left as-is.
+ */
+export function decodeModel<T>(value: unknown, model: string): T {
+  return decodeWire(value, model) as T;
+}
+
+function decodeWire(value: unknown, model: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => decodeWire(item, model));
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  const fields = WIRE_MODELS[model];
+  if (fields === undefined) {
+    return value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    const spec = fields[key];
+    if (spec === undefined) {
+      out[key] = val;
+    } else if (spec.model !== undefined) {
+      out[spec.name] = decodeWire(val, spec.model);
+    } else {
+      out[spec.name] = val;
+    }
+  }
+  return out;
+}

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1239,6 +1239,7 @@ describe("validateAgentName", () => {
 });
 
 describe("Agents create/apply with harness fields (EVE-686)", () => {
+  // The API serializes responses in snake_case (this mirrors the real wire).
   function agentFetchMock() {
     return vi.fn().mockResolvedValue({
       ok: true,
@@ -1246,12 +1247,15 @@ describe("Agents create/apply with harness fields (EVE-686)", () => {
       json: async () => ({
         id: "agent_123",
         name: "customer-support",
-        systemPrompt: "You are helpful.",
-        harnessId: "harness_abc",
-        parallelToolCalls: true,
+        system_prompt: "You are helpful.",
+        harness_id: "harness_abc",
+        parallel_tool_calls: true,
         status: "active",
-        createdAt: "2026-03-13T00:00:00Z",
-        updatedAt: "2026-03-13T00:00:00Z",
+        initial_files: [
+          { path: "README.md", content: "hi", is_readonly: true },
+        ],
+        created_at: "2026-03-13T00:00:00Z",
+        updated_at: "2026-03-13T00:00:00Z",
       }),
     });
   }
@@ -1375,29 +1379,61 @@ describe("Agents create/apply with harness fields (EVE-686)", () => {
     ).rejects.toThrow("must match pattern");
   });
 
-  // NOTE: response-field parsing (agent.harnessId etc.) is intentionally not
-  // asserted here. The API returns snake_case (harness_id) and the client casts
-  // response.json() directly to the camelCase-typed Agent with no transform, so
-  // multi-word response fields are undefined at runtime. This is a pre-existing,
-  // systemic, TypeScript-only issue (affects systemPrompt/createdAt/etc. too),
-  // out of scope for this adoption and tracked as a separate follow-up.
+  // Response parsing: the API returns snake_case; the client maps it onto the
+  // camelCase-typed Agent (issue #99). Assert the multi-word fields resolve,
+  // including nested models (initialFiles[].isReadonly).
+  it("should map snake_case response fields onto the camelCase Agent", async () => {
+    const fetchMock = agentFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new Everruns({ apiKey: "evr_test_key" });
+
+    const agent = await client.agents.create({
+      name: "customer-support",
+      systemPrompt: "You are helpful.",
+      harnessId: "harness_abc",
+    });
+
+    expect(agent.systemPrompt).toBe("You are helpful.");
+    expect(agent.harnessId).toBe("harness_abc");
+    expect(agent.parallelToolCalls).toBe(true);
+    expect(agent.createdAt).toBe("2026-03-13T00:00:00Z");
+    expect(agent.updatedAt).toBe("2026-03-13T00:00:00Z");
+    // Nested model fields decode too.
+    expect(agent.initialFiles?.[0].isReadonly).toBe(true);
+    expect(agent.initialFiles?.[0].path).toBe("README.md");
+    // Single-word fields are untouched.
+    expect(agent.id).toBe("agent_123");
+    expect(agent.name).toBe("customer-support");
+  });
+
+  it("should map snake_case response fields from agents.get", async () => {
+    const fetchMock = agentFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new Everruns({ apiKey: "evr_test_key" });
+
+    const agent = await client.agents.get("agent_123");
+
+    expect(agent.systemPrompt).toBe("You are helpful.");
+    expect(agent.harnessId).toBe("harness_abc");
+  });
 });
 
 describe("Sessions create with agentName and parallelToolCalls (EVE-686)", () => {
+  // The API serializes responses in snake_case (this mirrors the real wire).
   function sessionFetchMock() {
     return vi.fn().mockResolvedValue({
       ok: true,
       status: 201,
       json: async () => ({
         id: "session_123",
-        harnessId: "harness_123",
-        agentId: "agent_123",
-        parallelToolCalls: true,
-        forkedFromSessionId: "session_parent",
-        forkedFromSequence: 42,
+        harness_id: "harness_123",
+        agent_id: "agent_123",
+        parallel_tool_calls: true,
+        forked_from_session_id: "session_parent",
+        forked_from_sequence: 42,
         status: "active",
-        createdAt: "2026-03-13T00:00:00Z",
-        updatedAt: "2026-03-13T00:00:00Z",
+        created_at: "2026-03-13T00:00:00Z",
+        updated_at: "2026-03-13T00:00:00Z",
       }),
     });
   }
@@ -1437,10 +1473,26 @@ describe("Sessions create with agentName and parallelToolCalls (EVE-686)", () =>
     ).rejects.toThrow("must match pattern");
   });
 
-  // NOTE: see the agent-response note above — snake_case response fields
-  // (parallel_tool_calls, forked_from_session_id, forked_from_sequence) are not
-  // mapped to the camelCase-typed Session at runtime. Pre-existing TS-only issue,
-  // tracked separately; not asserted here to avoid false confidence.
+  // Response parsing: snake_case wire fields map onto the camelCase-typed
+  // Session, including the EVE-686 additions (issue #99).
+  it("should map snake_case response fields onto the camelCase Session", async () => {
+    const fetchMock = sessionFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new Everruns({ apiKey: "evr_test_key" });
+
+    const session = await client.sessions.create({
+      agentName: "customer-support",
+    });
+
+    expect(session.harnessId).toBe("harness_123");
+    expect(session.agentId).toBe("agent_123");
+    expect(session.parallelToolCalls).toBe(true);
+    expect(session.forkedFromSessionId).toBe("session_parent");
+    expect(session.forkedFromSequence).toBe(42);
+    expect(session.createdAt).toBe("2026-03-13T00:00:00Z");
+    expect(session.updatedAt).toBe("2026-03-13T00:00:00Z");
+    expect(session.id).toBe("session_123");
+  });
 });
 
 describe("CreateAgentRequest with displayName", () => {
@@ -2488,7 +2540,10 @@ describe("Session budget shortcuts", () => {
     const client = new Everruns({ apiKey: "evr_test_key" });
     const result = await client.sessions.resume("sess_123");
 
-    expect(result.resumed_budgets).toBe(2);
+    // The API returns snake_case (`resumed_budgets`); the client decodes it to
+    // the camelCase `resumedBudgets` declared on ResumeSessionResponse.
+    expect(result.resumedBudgets).toBe(2);
+    expect(result.sessionId).toBe("sess_123");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://custom.example.com/api/v1/sessions/sess_123/resume",
       expect.objectContaining({ method: "POST" }),
@@ -2788,5 +2843,128 @@ describe("ModelsClient", () => {
       "https://custom.example.com/api/v1/models/model_123",
       expect.objectContaining({ headers: expect.any(Object) }),
     );
+  });
+});
+
+describe("Response decoding invariants (issue #99)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should decode deeply nested camelCase models", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "model_123",
+        model_id: "gpt-4",
+        display_name: "GPT-4",
+        provider_id: "provider_1",
+        provider_name: "OpenAI",
+        provider_type: "openai",
+        source: "builtin",
+        capabilities: [],
+        enabled: true,
+        healthy: true,
+        is_favorite: false,
+        created_at: "2026-07-01T00:00:00Z",
+        updated_at: "2026-07-01T00:00:00Z",
+        profile: {
+          name: "gpt-4",
+          family: "gpt",
+          attachment: false,
+          reasoning: true,
+          temperature: true,
+          tool_call: true,
+          open_weights: false,
+          structured_output: true,
+          release_date: "2026-01-01",
+          cost: { input: 1, output: 2, cache_read: 0.5 },
+          limits: { context: 128000, output: 4096, max_media: 10 },
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new Everruns({ apiKey: "evr_test_key" });
+
+    const model = await client.models.get("model_123");
+
+    expect(model.providerName).toBe("OpenAI");
+    expect(model.isFavorite).toBe(false);
+    // Two and three levels deep.
+    expect(model.profile?.releaseDate).toBe("2026-01-01");
+    expect(model.profile?.cost?.cacheRead).toBe(0.5);
+    expect(model.profile?.limits?.maxMedia).toBe(10);
+  });
+
+  it("should leave free-form object keys untouched", async () => {
+    // Event.data is a free-form Record; its snake_case keys are data, not
+    // model fields, and must survive verbatim. Event.ts still maps to createdAt.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "evt_1",
+            ts: "2026-07-01T00:00:00Z",
+            type: "tool.call_requested",
+            data: {
+              tool_name: "search",
+              nested_map: { deep_key: 42 },
+            },
+          },
+        ],
+        total: 1,
+        offset: 0,
+        limit: 25,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new Everruns({ apiKey: "evr_test_key" });
+
+    const events = await client.events.list("sess_123");
+
+    expect(events[0].createdAt).toBe("2026-07-01T00:00:00Z");
+    // Free-form keys are preserved exactly (NOT camelCased).
+    expect(events[0].data.tool_name).toBe("search");
+    expect((events[0].data.nested_map as { deep_key: number }).deep_key).toBe(
+      42,
+    );
+    expect(events[0].data.toolName).toBeUndefined();
+  });
+
+  it("should preserve data-bearing map keys inside model fields", async () => {
+    // Agent.capabilities[].config is free-form; its keys must not be rewritten,
+    // while the surrounding model fields still decode.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: "agent_123",
+        name: "assistant",
+        system_prompt: "hi",
+        harness_id: "harness_1",
+        status: "active",
+        capabilities: [
+          { ref: "web-search", config: { max_results: 5, api_key: "k" } },
+        ],
+        created_at: "2026-07-01T00:00:00Z",
+        updated_at: "2026-07-01T00:00:00Z",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new Everruns({ apiKey: "evr_test_key" });
+
+    const agent = await client.agents.get("agent_123");
+
+    expect(agent.systemPrompt).toBe("hi");
+    expect(agent.capabilities?.[0].ref).toBe("web-search");
+    const config = agent.capabilities?.[0].config as {
+      max_results: number;
+      api_key: string;
+    };
+    expect(config.max_results).toBe(5);
+    expect(config.api_key).toBe("k");
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #99: `Client.fetch` cast `response.json()` straight to the camelCase-typed models, but the API serializes responses in **snake_case**. Every multi-word response field (`systemPrompt`, `harnessId`, `createdAt`, `parallelToolCalls`, `forkedFromSessionId`, …) was `undefined` at runtime; single-word fields (`id`, `name`, `status`) worked by coincidence. Rust and Python were unaffected — they type snake_case response fields matching the wire.
- The generator now emits a `WIRE_MODELS` decode map and a `decodeModel()` runtime into `models.ts`, and `Client.fetch` runs every JSON response through it (envelope responses decode their inner array at the call site).
- The transform is **schema-targeted, not a blanket recursive rename**: only known model keys are renamed and nested typed models are recursed. Free-form object fields (`Record<string, unknown>` / `unknown` — capability config, event `data`, tool arguments, storage secrets, blueprint config) carry no descriptor entry, so their data-bearing keys pass through untouched. Explicit renames (`Event.ts → createdAt`, `default_model_id → model`) are honored.

## Test Plan

Added response-parsing tests that mock **snake_case** wire bodies (matching the real API) and assert the camelCase fields resolve — the absence of such tests is what hid this. Coverage includes top-level fields, nested models (`initialFiles[].isReadonly`, `profile.releaseDate`, `profile.cost.cacheRead`), and free-form-key preservation (event `data`, capability `config`). Replaced the two prior camelCase mocks (which masked the bug) and the fix-tracking `NOTE` comments. Added a generator unit test for the emitted decode map.

- [x] Tests pass locally (`vitest`: 170 passed; generator: 12 passed)
- [x] Coverage ≥80%
- [x] Linting passes (`tsc --noEmit`, `oxlint`, `prettier --check`, `generate --check`, examples typecheck)

## Checklist

- [x] Follows SDK API consistency guidelines (camelCase surface preserved across languages; wire mapping now matches Rust/Python behavior)
- [x] Updated relevant specs (if applicable) — n/a
- [x] Added/updated tests
- [x] Updated documentation (if applicable) — n/a


---
_Generated by [Claude Code](https://claude.ai/code/session_01VdKCVwgaB6M3B3FEgnzHCJ)_