### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.0] - 2026-07-11
 
 ### Highlights
 
@@ -11,6 +11,22 @@
 - Models API (read-only): list and get available models across all SDKs, for choosing an agent's `default_model_id`.
 - Fixed (TypeScript): response objects for `Agent`, `Session`, `Harness`, `ModelWithProvider`, `CapabilityInfo`, `Budget`, `Connection`, and `Message` now expose their fields in snake_case matching the wire, so multi-word fields (e.g. `harness_id`, `system_prompt`, `created_at`, `provider_type`) resolve at runtime instead of being `undefined`. Rust and Python were already correct.
 - Refreshed generated schemas from upstream OpenAPI.
+
+### Breaking Changes
+
+- **TypeScript response fields are now snake_case**: response objects (`Agent`, `Session`, `Harness`, `ModelWithProvider`, `CapabilityInfo`, `Budget`, `Connection`, `Message`, and related) now expose multi-word fields in snake_case, matching the wire. Previously these were typed camelCase but resolved to `undefined` at runtime. Update any code reading these fields.
+  - Before: `agent.harnessId`, `session.systemPrompt`, `message.createdAt` (were `undefined`)
+  - After: `agent.harness_id`, `session.system_prompt`, `message.created_at`
+  - Rust and Python were already snake_case and are unaffected. TypeScript request models remain camelCase.
+
+### What's Changed
+
+* fix(typescript): snake_case response models ([#102](https://github.com/everruns/sdk/pull/102)) by @chaliy
+* feat: add harnesses and models SDK APIs ([#101](https://github.com/everruns/sdk/pull/101)) by @chaliy
+* feat: generate public SDK models from OpenAPI ([#100](https://github.com/everruns/sdk/pull/100)) by @chaliy
+* feat: adopt agent harness ownership and agent-first sessions (EVE-686) ([#98](https://github.com/everruns/sdk/pull/98)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/sdk/compare/v0.1.10...v0.2.0
 
 ## [0.1.10] - 2026-06-19
 

--- a/python/everruns_sdk/__init__.py
+++ b/python/everruns_sdk/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "validate_harness_name",
 ]
 
-__version__ = "0.1.10"
+__version__ = "0.2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "everruns-sdk"
-version = "0.1.10"
+version = "0.2.0"
 description = "Python SDK for Everruns API"
 readme = "README.md"
 license = "MIT"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -172,7 +172,7 @@ toml = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.10"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-sdk"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2024"
 description = "Rust SDK for Everruns API"
 authors = ["Everruns <support@everruns.com>"]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/sdk",
-      "version": "0.1.10",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/sdk",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "TypeScript SDK for Everruns API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump Rust, Python, and TypeScript SDK package versions to `0.2.0` (manifests + lockfiles + Python `__version__`).
- Minor bump: this release adds new endpoint families (Harnesses + Models APIs) and carries a breaking TypeScript response-model change (camelCase → snake_case, see CHANGELOG).
- Add the `0.2.0` CHANGELOG entry covering PRs #98, #100, #101, #102 (agent harness ownership + agent-first sessions, OpenAPI-driven model codegen, Harnesses + Models APIs, and the TypeScript snake_case response-model fix).

Merging this `chore(release): prepare v0.2.0` commit to `main` triggers `release.yml` to tag `v0.2.0`, create the GitHub Release, and publish to crates.io, PyPI, and npm.

## Test Plan

- [x] Tests pass locally: `cargo test` (17 + 2 doctests), `uv run pytest` (179), `npm test` (166)
- [x] Coverage ≥80%: existing suite maintained; release-only change
- [x] Linting passes: `cargo fmt`/`clippy`, `ruff check`/`format`, `oxlint`
- [x] `generate.py --check` idempotent; generator tests (11) pass
- [x] `publish-dry-run`: `cargo publish --dry-run`, `uv build`, `npm run build` all succeed
- [x] Pre-push attribution check passes

## Checklist

- [x] Follows SDK API consistency guidelines
- [x] Updated relevant specs (if applicable) — n/a, release-only
- [x] Added/updated tests — n/a, release-only
- [x] Updated documentation (CHANGELOG.md)